### PR TITLE
Avoid creating object mappers all the time

### DIFF
--- a/core/src/main/java/org/dcsa/conformance/core/Util.java
+++ b/core/src/main/java/org/dcsa/conformance/core/Util.java
@@ -1,7 +1,0 @@
-package org.dcsa.conformance.core;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-public class Util {
-  public static final ObjectMapper STATE_OBJECT_MAPPER = new ObjectMapper();
-}

--- a/core/src/main/java/org/dcsa/conformance/core/Util.java
+++ b/core/src/main/java/org/dcsa/conformance/core/Util.java
@@ -1,0 +1,7 @@
+package org.dcsa.conformance.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class Util {
+  public static final ObjectMapper STATE_OBJECT_MAPPER = new ObjectMapper();
+}

--- a/core/src/main/java/org/dcsa/conformance/core/check/JsonSchemaValidator.java
+++ b/core/src/main/java/org/dcsa/conformance/core/check/JsonSchemaValidator.java
@@ -11,8 +11,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+
 public class JsonSchemaValidator {
   private static final Map<String, Map<String, JsonSchemaValidator>> INSTANCES = new HashMap<>();
+  private static final ObjectMapper JSON_FACTORY_OBJECT_MAPPER = new ObjectMapper(new JsonFactory());
 
   public static synchronized JsonSchemaValidator getInstance(String filePath, String schemaName) {
     return INSTANCES
@@ -28,7 +31,7 @@ public class JsonSchemaValidator {
     InputStream schemaFileInputStream = JsonSchemaValidator.class.getResourceAsStream(filePath);
     JsonSchemaFactory jsonSchemaFactory =
         JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7))
-            .objectMapper(new ObjectMapper(new JsonFactory()))
+            .objectMapper(JSON_FACTORY_OBJECT_MAPPER)
             .build();
     SchemaValidatorsConfig schemaValidatorsConfig = new SchemaValidatorsConfig();
     schemaValidatorsConfig.setTypeLoose(false);
@@ -52,7 +55,7 @@ public class JsonSchemaValidator {
 
   @SneakyThrows
   public Set<String> validate(String jsonString) {
-    return validate(new ObjectMapper().readTree(jsonString));
+    return validate(STATE_OBJECT_MAPPER.readTree(jsonString));
   }
 
   public Set<String> validate(JsonNode jsonNode) {

--- a/core/src/main/java/org/dcsa/conformance/core/check/JsonSchemaValidator.java
+++ b/core/src/main/java/org/dcsa/conformance/core/check/JsonSchemaValidator.java
@@ -11,7 +11,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 public class JsonSchemaValidator {
   private static final Map<String, Map<String, JsonSchemaValidator>> INSTANCES = new HashMap<>();
@@ -55,7 +55,7 @@ public class JsonSchemaValidator {
 
   @SneakyThrows
   public Set<String> validate(String jsonString) {
-    return validate(STATE_OBJECT_MAPPER.readTree(jsonString));
+    return validate(OBJECT_MAPPER.readTree(jsonString));
   }
 
   public Set<String> validate(JsonNode jsonNode) {

--- a/core/src/main/java/org/dcsa/conformance/core/party/ActionPromptsQueue.java
+++ b/core/src/main/java/org/dcsa/conformance/core/party/ActionPromptsQueue.java
@@ -11,6 +11,8 @@ import java.util.stream.StreamSupport;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.dcsa.conformance.core.state.StatefulEntity;
 
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+
 public class ActionPromptsQueue implements StatefulEntity {
   private final Set<String> allActionIds = new HashSet<>();
   private final LinkedList<JsonNode> pendingActions = new LinkedList<>();
@@ -38,14 +40,12 @@ public class ActionPromptsQueue implements StatefulEntity {
 
   @Override
   synchronized public JsonNode exportJsonState() {
-    ObjectMapper objectMapper = new ObjectMapper();
-    ObjectNode stateNode = objectMapper.createObjectNode();
+    ObjectNode stateNode = STATE_OBJECT_MAPPER.createObjectNode();
 
-    ArrayNode allActionIdsNode = objectMapper.createArrayNode();
+    ArrayNode allActionIdsNode = stateNode.putArray("allActionIds");
     allActionIds.forEach(allActionIdsNode::add);
-    stateNode.set("allActionIds", allActionIdsNode);
 
-    ArrayNode pendingActionsNode = objectMapper.createArrayNode();
+    ArrayNode pendingActionsNode = stateNode.putArray("pendingActions");
     pendingActions.forEach(pendingActionsNode::add);
     stateNode.set("pendingActions", pendingActionsNode);
 

--- a/core/src/main/java/org/dcsa/conformance/core/party/ActionPromptsQueue.java
+++ b/core/src/main/java/org/dcsa/conformance/core/party/ActionPromptsQueue.java
@@ -1,7 +1,6 @@
 package org.dcsa.conformance.core.party;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -11,7 +10,7 @@ import java.util.stream.StreamSupport;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.dcsa.conformance.core.state.StatefulEntity;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 public class ActionPromptsQueue implements StatefulEntity {
   private final Set<String> allActionIds = new HashSet<>();
@@ -40,7 +39,7 @@ public class ActionPromptsQueue implements StatefulEntity {
 
   @Override
   synchronized public JsonNode exportJsonState() {
-    ObjectNode stateNode = STATE_OBJECT_MAPPER.createObjectNode();
+    ObjectNode stateNode = OBJECT_MAPPER.createObjectNode();
 
     ArrayNode allActionIdsNode = stateNode.putArray("allActionIds");
     allActionIds.forEach(allActionIdsNode::add);

--- a/core/src/main/java/org/dcsa/conformance/core/party/ConformanceParty.java
+++ b/core/src/main/java/org/dcsa/conformance/core/party/ConformanceParty.java
@@ -23,6 +23,8 @@ import org.dcsa.conformance.core.traffic.ConformanceMessageBody;
 import org.dcsa.conformance.core.traffic.ConformanceRequest;
 import org.dcsa.conformance.core.traffic.ConformanceResponse;
 
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+
 @Slf4j
 public abstract class ConformanceParty implements StatefulEntity {
   protected final String apiVersion;
@@ -68,10 +70,10 @@ public abstract class ConformanceParty implements StatefulEntity {
 
   @Override
   public JsonNode exportJsonState() {
-    ObjectNode jsonPartyState = new ObjectMapper().createObjectNode();
+    ObjectNode jsonPartyState = STATE_OBJECT_MAPPER.createObjectNode();
     jsonPartyState.set("actionPromptsQueue", actionPromptsQueue.exportJsonState());
 
-    ArrayNode operatorLogNode = new ObjectMapper().createArrayNode();
+    ArrayNode operatorLogNode = jsonPartyState.putArray("operatorLog");
     operatorLog.forEach(operatorLogNode::add);
     jsonPartyState.set("operatorLog", operatorLogNode);
 

--- a/core/src/main/java/org/dcsa/conformance/core/party/ConformanceParty.java
+++ b/core/src/main/java/org/dcsa/conformance/core/party/ConformanceParty.java
@@ -1,7 +1,6 @@
 package org.dcsa.conformance.core.party;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.net.URI;
@@ -23,7 +22,7 @@ import org.dcsa.conformance.core.traffic.ConformanceMessageBody;
 import org.dcsa.conformance.core.traffic.ConformanceRequest;
 import org.dcsa.conformance.core.traffic.ConformanceResponse;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 @Slf4j
 public abstract class ConformanceParty implements StatefulEntity {
@@ -70,7 +69,7 @@ public abstract class ConformanceParty implements StatefulEntity {
 
   @Override
   public JsonNode exportJsonState() {
-    ObjectNode jsonPartyState = STATE_OBJECT_MAPPER.createObjectNode();
+    ObjectNode jsonPartyState = OBJECT_MAPPER.createObjectNode();
     jsonPartyState.set("actionPromptsQueue", actionPromptsQueue.exportJsonState());
 
     ArrayNode operatorLogNode = jsonPartyState.putArray("operatorLog");

--- a/core/src/main/java/org/dcsa/conformance/core/report/ConformanceReport.java
+++ b/core/src/main/java/org/dcsa/conformance/core/report/ConformanceReport.java
@@ -19,6 +19,8 @@ import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+
 @Getter
 public class ConformanceReport {
   private final ConformanceCheck conformanceCheck;
@@ -90,19 +92,16 @@ public class ConformanceReport {
   }
 
   public JsonNode toJsonReport() {
-    ObjectMapper objectMapper = new ObjectMapper();
-    ObjectNode reportNode = objectMapper.createObjectNode();
+    ObjectNode reportNode = STATE_OBJECT_MAPPER.createObjectNode();
 
     reportNode.put("title", title);
     reportNode.put("status", conformanceStatus.name());
 
-    ArrayNode subReportsNode = objectMapper.createArrayNode();
+    ArrayNode subReportsNode = reportNode.putArray("subReports");
     subReports.forEach(subReport -> subReportsNode.add(subReport.toJsonReport()));
-    reportNode.set("subReports", subReportsNode);
 
-    ArrayNode errorsNode = objectMapper.createArrayNode();
+    ArrayNode errorsNode = reportNode.putArray("errorMessages");
     errorMessages.forEach(errorsNode::add);
-    reportNode.set("errorMessages", errorsNode);
 
     return reportNode;
   }

--- a/core/src/main/java/org/dcsa/conformance/core/report/ConformanceReport.java
+++ b/core/src/main/java/org/dcsa/conformance/core/report/ConformanceReport.java
@@ -1,7 +1,6 @@
 package org.dcsa.conformance.core.report;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.InputStream;
@@ -13,13 +12,7 @@ import lombok.Getter;
 import lombok.SneakyThrows;
 import org.dcsa.conformance.core.check.ConformanceCheck;
 
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 @Getter
 public class ConformanceReport {
@@ -92,7 +85,7 @@ public class ConformanceReport {
   }
 
   public JsonNode toJsonReport() {
-    ObjectNode reportNode = STATE_OBJECT_MAPPER.createObjectNode();
+    ObjectNode reportNode = OBJECT_MAPPER.createObjectNode();
 
     reportNode.put("title", title);
     reportNode.put("status", conformanceStatus.name());

--- a/core/src/main/java/org/dcsa/conformance/core/scenario/ConformanceAction.java
+++ b/core/src/main/java/org/dcsa/conformance/core/scenario/ConformanceAction.java
@@ -1,7 +1,6 @@
 package org.dcsa.conformance.core.scenario;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Objects;
 import java.util.UUID;
@@ -11,7 +10,7 @@ import org.dcsa.conformance.core.check.ConformanceCheck;
 import org.dcsa.conformance.core.state.StatefulEntity;
 import org.dcsa.conformance.core.traffic.ConformanceExchange;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 @Getter
 @Slf4j
@@ -47,7 +46,7 @@ public abstract class ConformanceAction implements StatefulEntity {
 
   @Override
   public ObjectNode exportJsonState() {
-    ObjectNode jsonState = STATE_OBJECT_MAPPER.createObjectNode();
+    ObjectNode jsonState = OBJECT_MAPPER.createObjectNode();
     jsonState.put("id", id.toString());
     if (matchedExchangeUuid != null) {
       jsonState.put("matchedExchangeUuid", matchedExchangeUuid.toString());
@@ -149,7 +148,7 @@ public abstract class ConformanceAction implements StatefulEntity {
   public void handlePartyInput(JsonNode partyInput) {}
 
   public ObjectNode asJsonNode() {
-    return STATE_OBJECT_MAPPER
+    return OBJECT_MAPPER
         .createObjectNode()
         .put("actionId", id.toString())
         .put("actionType", getClass().getCanonicalName())

--- a/core/src/main/java/org/dcsa/conformance/core/scenario/ConformanceAction.java
+++ b/core/src/main/java/org/dcsa/conformance/core/scenario/ConformanceAction.java
@@ -11,9 +11,12 @@ import org.dcsa.conformance.core.check.ConformanceCheck;
 import org.dcsa.conformance.core.state.StatefulEntity;
 import org.dcsa.conformance.core.traffic.ConformanceExchange;
 
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+
 @Getter
 @Slf4j
 public abstract class ConformanceAction implements StatefulEntity {
+
   private final String sourcePartyName;
   private final String targetPartyName;
   protected final ConformanceAction previousAction;
@@ -44,7 +47,7 @@ public abstract class ConformanceAction implements StatefulEntity {
 
   @Override
   public ObjectNode exportJsonState() {
-    ObjectNode jsonState = new ObjectMapper().createObjectNode();
+    ObjectNode jsonState = STATE_OBJECT_MAPPER.createObjectNode();
     jsonState.put("id", id.toString());
     if (matchedExchangeUuid != null) {
       jsonState.put("matchedExchangeUuid", matchedExchangeUuid.toString());
@@ -146,7 +149,7 @@ public abstract class ConformanceAction implements StatefulEntity {
   public void handlePartyInput(JsonNode partyInput) {}
 
   public ObjectNode asJsonNode() {
-    return new ObjectMapper()
+    return STATE_OBJECT_MAPPER
         .createObjectNode()
         .put("actionId", id.toString())
         .put("actionType", getClass().getCanonicalName())

--- a/core/src/main/java/org/dcsa/conformance/core/scenario/ConformanceScenario.java
+++ b/core/src/main/java/org/dcsa/conformance/core/scenario/ConformanceScenario.java
@@ -16,6 +16,8 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+
 @Slf4j
 public class ConformanceScenario implements StatefulEntity {
   @Getter private final String title;
@@ -40,14 +42,13 @@ public class ConformanceScenario implements StatefulEntity {
 
   @Override
   public JsonNode exportJsonState() {
-    ObjectNode jsonState = new ObjectMapper().createObjectNode();
+    ObjectNode jsonState = STATE_OBJECT_MAPPER.createObjectNode();
     jsonState.put("id", id.toString());
 
     jsonState.put("nextActionsSize", nextActions.size());
 
-    ArrayNode actionsArrayNode = new ObjectMapper().createArrayNode();
+    ArrayNode actionsArrayNode = jsonState.putArray("allActions");
     allActions.forEach(action -> actionsArrayNode.add(action.exportJsonState()));
-    jsonState.set("allActions", actionsArrayNode);
 
     return jsonState;
   }

--- a/core/src/main/java/org/dcsa/conformance/core/scenario/ConformanceScenario.java
+++ b/core/src/main/java/org/dcsa/conformance/core/scenario/ConformanceScenario.java
@@ -1,7 +1,6 @@
 package org.dcsa.conformance.core.scenario;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Getter;
@@ -16,7 +15,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 @Slf4j
 public class ConformanceScenario implements StatefulEntity {
@@ -42,7 +41,7 @@ public class ConformanceScenario implements StatefulEntity {
 
   @Override
   public JsonNode exportJsonState() {
-    ObjectNode jsonState = STATE_OBJECT_MAPPER.createObjectNode();
+    ObjectNode jsonState = OBJECT_MAPPER.createObjectNode();
     jsonState.put("id", id.toString());
 
     jsonState.put("nextActionsSize", nextActions.size());

--- a/core/src/main/java/org/dcsa/conformance/core/state/MemorySortedPartitionsNonLockingMap.java
+++ b/core/src/main/java/org/dcsa/conformance/core/state/MemorySortedPartitionsNonLockingMap.java
@@ -8,26 +8,26 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.TreeMap;
 
-public class MemorySortedPartitionsNonLockingMap implements SortedPartitionsNonLockingMap {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
 
+public class MemorySortedPartitionsNonLockingMap implements SortedPartitionsNonLockingMap {
   private final HashMap<String, TreeMap<String, JsonNode>> memoryMap = new HashMap<>();
 
 
   @SneakyThrows
   @Override
   public synchronized void setItemValue(String partitionKey, String sortKey, JsonNode value) {
-    JsonNode valueCopy = OBJECT_MAPPER.readTree(value.toString());
+    JsonNode valueCopy = STATE_OBJECT_MAPPER.readTree(value.toString());
     memoryMap
         .computeIfAbsent(partitionKey, (ignoredKey) -> new TreeMap<>())
-        .put(sortKey, OBJECT_MAPPER.createObjectNode().set("value", valueCopy));
+        .put(sortKey, STATE_OBJECT_MAPPER.createObjectNode().set("value", valueCopy));
   }
 
   @Override
   public synchronized JsonNode getItemValue(String partitionKey, String sortKey) {
     return memoryMap
         .getOrDefault(partitionKey, new TreeMap<>())
-        .getOrDefault(sortKey, OBJECT_MAPPER.createObjectNode())
+        .getOrDefault(sortKey, STATE_OBJECT_MAPPER.createObjectNode())
         .get("value");
   }
 

--- a/core/src/main/java/org/dcsa/conformance/core/state/MemorySortedPartitionsNonLockingMap.java
+++ b/core/src/main/java/org/dcsa/conformance/core/state/MemorySortedPartitionsNonLockingMap.java
@@ -1,14 +1,13 @@
 package org.dcsa.conformance.core.state;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.TreeMap;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 public class MemorySortedPartitionsNonLockingMap implements SortedPartitionsNonLockingMap {
   private final HashMap<String, TreeMap<String, JsonNode>> memoryMap = new HashMap<>();
@@ -17,17 +16,17 @@ public class MemorySortedPartitionsNonLockingMap implements SortedPartitionsNonL
   @SneakyThrows
   @Override
   public synchronized void setItemValue(String partitionKey, String sortKey, JsonNode value) {
-    JsonNode valueCopy = STATE_OBJECT_MAPPER.readTree(value.toString());
+    JsonNode valueCopy = OBJECT_MAPPER.readTree(value.toString());
     memoryMap
         .computeIfAbsent(partitionKey, (ignoredKey) -> new TreeMap<>())
-        .put(sortKey, STATE_OBJECT_MAPPER.createObjectNode().set("value", valueCopy));
+        .put(sortKey, OBJECT_MAPPER.createObjectNode().set("value", valueCopy));
   }
 
   @Override
   public synchronized JsonNode getItemValue(String partitionKey, String sortKey) {
     return memoryMap
         .getOrDefault(partitionKey, new TreeMap<>())
-        .getOrDefault(sortKey, STATE_OBJECT_MAPPER.createObjectNode())
+        .getOrDefault(sortKey, OBJECT_MAPPER.createObjectNode())
         .get("value");
   }
 

--- a/core/src/main/java/org/dcsa/conformance/core/toolkit/JsonToolkit.java
+++ b/core/src/main/java/org/dcsa/conformance/core/toolkit/JsonToolkit.java
@@ -1,9 +1,9 @@
 package org.dcsa.conformance.core.toolkit;
 
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -19,12 +19,12 @@ public enum JsonToolkit {
 
   @SneakyThrows
   public static JsonNode stringToJsonNode(String string) {
-    return new ObjectMapper().readTree(string);
+    return STATE_OBJECT_MAPPER.readTree(string);
   }
 
   @SneakyThrows
   public static JsonNode inputStreamToJsonNode(InputStream inputStream) {
-    return new ObjectMapper().readTree(inputStream);
+    return STATE_OBJECT_MAPPER.readTree(inputStream);
   }
 
   @SneakyThrows
@@ -36,7 +36,7 @@ public enum JsonToolkit {
           new String(Objects.requireNonNull(inputStream).readAllBytes(), StandardCharsets.UTF_8));
     }
     replacements.forEach((key, value) -> jsonString.set(jsonString.get().replaceAll(key, value)));
-    return new ObjectMapper().readTree(jsonString.get());
+    return STATE_OBJECT_MAPPER.readTree(jsonString.get());
   }
 
   public static boolean stringAttributeEquals(JsonNode jsonNode, String name, String value) {
@@ -49,7 +49,7 @@ public enum JsonToolkit {
   }
 
   public static ArrayNode stringCollectionToArrayNode(Collection<String> strings) {
-    ArrayNode arrayNode = new ObjectMapper().createArrayNode();
+    ArrayNode arrayNode = STATE_OBJECT_MAPPER.createArrayNode();
     strings.forEach(arrayNode::add);
     return arrayNode;
   }
@@ -62,14 +62,12 @@ public enum JsonToolkit {
 
   public static ArrayNode mapOfStringToStringCollectionToJson(
       Map<String, ? extends Collection<String>> map) {
-    ObjectMapper objectMapper = new ObjectMapper();
-    ArrayNode queryParamsNode = objectMapper.createArrayNode();
+    ArrayNode queryParamsNode = STATE_OBJECT_MAPPER.createArrayNode();
     map.forEach(
         (key, values) -> {
-          ObjectNode entryNode = objectMapper.createObjectNode();
-          entryNode.put("key", key);
-          entryNode.set("values", JsonToolkit.stringCollectionToArrayNode(values));
-          queryParamsNode.add(entryNode);
+          queryParamsNode.addObject()
+            .put("key", key)
+            .set("values", JsonToolkit.stringCollectionToArrayNode(values));;
         });
     return queryParamsNode;
   }

--- a/core/src/main/java/org/dcsa/conformance/core/toolkit/JsonToolkit.java
+++ b/core/src/main/java/org/dcsa/conformance/core/toolkit/JsonToolkit.java
@@ -1,8 +1,7 @@
 package org.dcsa.conformance.core.toolkit;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
-
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -16,15 +15,16 @@ public enum JsonToolkit {
   ; // no instances
 
   public static final String JSON_UTF_8 = "application/json";
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @SneakyThrows
   public static JsonNode stringToJsonNode(String string) {
-    return STATE_OBJECT_MAPPER.readTree(string);
+    return OBJECT_MAPPER.readTree(string);
   }
 
   @SneakyThrows
   public static JsonNode inputStreamToJsonNode(InputStream inputStream) {
-    return STATE_OBJECT_MAPPER.readTree(inputStream);
+    return OBJECT_MAPPER.readTree(inputStream);
   }
 
   @SneakyThrows
@@ -36,7 +36,7 @@ public enum JsonToolkit {
           new String(Objects.requireNonNull(inputStream).readAllBytes(), StandardCharsets.UTF_8));
     }
     replacements.forEach((key, value) -> jsonString.set(jsonString.get().replaceAll(key, value)));
-    return STATE_OBJECT_MAPPER.readTree(jsonString.get());
+    return OBJECT_MAPPER.readTree(jsonString.get());
   }
 
   public static boolean stringAttributeEquals(JsonNode jsonNode, String name, String value) {
@@ -49,7 +49,7 @@ public enum JsonToolkit {
   }
 
   public static ArrayNode stringCollectionToArrayNode(Collection<String> strings) {
-    ArrayNode arrayNode = STATE_OBJECT_MAPPER.createArrayNode();
+    ArrayNode arrayNode = OBJECT_MAPPER.createArrayNode();
     strings.forEach(arrayNode::add);
     return arrayNode;
   }
@@ -62,7 +62,7 @@ public enum JsonToolkit {
 
   public static ArrayNode mapOfStringToStringCollectionToJson(
       Map<String, ? extends Collection<String>> map) {
-    ArrayNode queryParamsNode = STATE_OBJECT_MAPPER.createArrayNode();
+    ArrayNode queryParamsNode = OBJECT_MAPPER.createArrayNode();
     map.forEach(
         (key, values) -> {
           queryParamsNode.addObject()

--- a/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceExchange.java
+++ b/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceExchange.java
@@ -1,12 +1,11 @@
 package org.dcsa.conformance.core.traffic;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.ToString;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 @ToString
 @Getter
@@ -26,7 +25,7 @@ public class ConformanceExchange {
   }
 
   public ObjectNode toJson() {
-    ObjectNode jsonState = STATE_OBJECT_MAPPER.createObjectNode();
+    ObjectNode jsonState = OBJECT_MAPPER.createObjectNode();
     jsonState.put("uuid", uuid.toString());
     jsonState.set("request", request.toJson());
     jsonState.set("response", response.toJson());

--- a/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceExchange.java
+++ b/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceExchange.java
@@ -6,6 +6,8 @@ import java.util.UUID;
 import lombok.Getter;
 import lombok.ToString;
 
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+
 @ToString
 @Getter
 public class ConformanceExchange {
@@ -24,7 +26,7 @@ public class ConformanceExchange {
   }
 
   public ObjectNode toJson() {
-    ObjectNode jsonState = new ObjectMapper().createObjectNode();
+    ObjectNode jsonState = STATE_OBJECT_MAPPER.createObjectNode();
     jsonState.put("uuid", uuid.toString());
     jsonState.set("request", request.toJson());
     jsonState.set("response", response.toJson());

--- a/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceMessage.java
+++ b/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceMessage.java
@@ -8,6 +8,8 @@ import org.dcsa.conformance.core.toolkit.JsonToolkit;
 import java.util.Collection;
 import java.util.Map;
 
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+
 public record ConformanceMessage(
     String sourcePartyName,
     String sourcePartyRole,
@@ -18,8 +20,7 @@ public record ConformanceMessage(
     long timestamp) {
 
   public ObjectNode toJson() {
-    ObjectMapper objectMapper = new ObjectMapper();
-    ObjectNode objectNode = objectMapper.createObjectNode();
+    ObjectNode objectNode = STATE_OBJECT_MAPPER.createObjectNode();
     objectNode.put("sourcePartyName", sourcePartyName);
     objectNode.put("sourcePartyRole", sourcePartyRole);
     objectNode.put("targetPartyName", targetPartyName);

--- a/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceMessage.java
+++ b/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceMessage.java
@@ -1,6 +1,5 @@
 package org.dcsa.conformance.core.traffic;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.dcsa.conformance.core.toolkit.JsonToolkit;
@@ -8,7 +7,7 @@ import org.dcsa.conformance.core.toolkit.JsonToolkit;
 import java.util.Collection;
 import java.util.Map;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 public record ConformanceMessage(
     String sourcePartyName,
@@ -20,7 +19,7 @@ public record ConformanceMessage(
     long timestamp) {
 
   public ObjectNode toJson() {
-    ObjectNode objectNode = STATE_OBJECT_MAPPER.createObjectNode();
+    ObjectNode objectNode = OBJECT_MAPPER.createObjectNode();
     objectNode.put("sourcePartyName", sourcePartyName);
     objectNode.put("sourcePartyRole", sourcePartyRole);
     objectNode.put("targetPartyName", targetPartyName);

--- a/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceMessageBody.java
+++ b/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceMessageBody.java
@@ -2,12 +2,11 @@ package org.dcsa.conformance.core.traffic;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Getter;
 import lombok.ToString;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 @Getter
 @ToString
@@ -21,10 +20,10 @@ public class ConformanceMessageBody {
     boolean isCorrectJson;
     JsonNode jsonBody;
     try {
-      jsonBody = STATE_OBJECT_MAPPER.readTree(this.stringBody);
+      jsonBody = OBJECT_MAPPER.readTree(this.stringBody);
       isCorrectJson = true;
     } catch (JsonProcessingException e) {
-      jsonBody = STATE_OBJECT_MAPPER.createObjectNode();
+      jsonBody = OBJECT_MAPPER.createObjectNode();
       isCorrectJson = false;
     }
     this.isCorrectJson = isCorrectJson;
@@ -38,7 +37,7 @@ public class ConformanceMessageBody {
   }
 
   public ObjectNode toJson() {
-    ObjectNode objectNode = STATE_OBJECT_MAPPER.createObjectNode();
+    ObjectNode objectNode = OBJECT_MAPPER.createObjectNode();
     objectNode.put("isCorrectJson", isCorrectJson);
     if (isCorrectJson) {
       objectNode.set("jsonBody", jsonBody);

--- a/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceMessageBody.java
+++ b/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceMessageBody.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Getter;
 import lombok.ToString;
 
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+
 @Getter
 @ToString
 public class ConformanceMessageBody {
@@ -19,10 +21,10 @@ public class ConformanceMessageBody {
     boolean isCorrectJson;
     JsonNode jsonBody;
     try {
-      jsonBody = new ObjectMapper().readTree(this.stringBody);
+      jsonBody = STATE_OBJECT_MAPPER.readTree(this.stringBody);
       isCorrectJson = true;
     } catch (JsonProcessingException e) {
-      jsonBody = new ObjectMapper().createObjectNode();
+      jsonBody = STATE_OBJECT_MAPPER.createObjectNode();
       isCorrectJson = false;
     }
     this.isCorrectJson = isCorrectJson;
@@ -36,8 +38,7 @@ public class ConformanceMessageBody {
   }
 
   public ObjectNode toJson() {
-    ObjectMapper objectMapper = new ObjectMapper();
-    ObjectNode objectNode = objectMapper.createObjectNode();
+    ObjectNode objectNode = STATE_OBJECT_MAPPER.createObjectNode();
     objectNode.put("isCorrectJson", isCorrectJson);
     if (isCorrectJson) {
       objectNode.set("jsonBody", jsonBody);

--- a/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceRequest.java
+++ b/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceRequest.java
@@ -10,6 +10,8 @@ import java.util.Collection;
 import java.util.Map;
 import org.dcsa.conformance.core.toolkit.JsonToolkit;
 
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+
 public record ConformanceRequest(
     String method,
     String url,
@@ -33,8 +35,7 @@ public record ConformanceRequest(
   }
 
   public ObjectNode toJson() {
-    ObjectMapper objectMapper = new ObjectMapper();
-    ObjectNode objectNode = objectMapper.createObjectNode();
+    ObjectNode objectNode = STATE_OBJECT_MAPPER.createObjectNode();
     objectNode.put("method", method);
     objectNode.put("url", url);
     objectNode.set("queryParams", JsonToolkit.mapOfStringToStringCollectionToJson(queryParams));

--- a/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceRequest.java
+++ b/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceRequest.java
@@ -1,6 +1,5 @@
 package org.dcsa.conformance.core.traffic;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -10,7 +9,7 @@ import java.util.Collection;
 import java.util.Map;
 import org.dcsa.conformance.core.toolkit.JsonToolkit;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 public record ConformanceRequest(
     String method,
@@ -35,7 +34,7 @@ public record ConformanceRequest(
   }
 
   public ObjectNode toJson() {
-    ObjectNode objectNode = STATE_OBJECT_MAPPER.createObjectNode();
+    ObjectNode objectNode = OBJECT_MAPPER.createObjectNode();
     objectNode.put("method", method);
     objectNode.put("url", url);
     objectNode.set("queryParams", JsonToolkit.mapOfStringToStringCollectionToJson(queryParams));

--- a/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceResponse.java
+++ b/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceResponse.java
@@ -1,14 +1,13 @@
 package org.dcsa.conformance.core.traffic;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 public record ConformanceResponse(int statusCode, ConformanceMessage message) {
 
   public ObjectNode toJson() {
-    ObjectNode objectNode = STATE_OBJECT_MAPPER.createObjectNode();
+    ObjectNode objectNode = OBJECT_MAPPER.createObjectNode();
     objectNode.put("statusCode", statusCode);
     objectNode.set("message", message.toJson());
     return objectNode;

--- a/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceResponse.java
+++ b/core/src/main/java/org/dcsa/conformance/core/traffic/ConformanceResponse.java
@@ -3,11 +3,12 @@ package org.dcsa.conformance.core.traffic;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+
 public record ConformanceResponse(int statusCode, ConformanceMessage message) {
 
   public ObjectNode toJson() {
-    ObjectMapper objectMapper = new ObjectMapper();
-    ObjectNode objectNode = objectMapper.createObjectNode();
+    ObjectNode objectNode = STATE_OBJECT_MAPPER.createObjectNode();
     objectNode.put("statusCode", statusCode);
     objectNode.set("message", message.toJson());
     return objectNode;

--- a/core/src/main/java/org/dcsa/conformance/core/traffic/TrafficRecorder.java
+++ b/core/src/main/java/org/dcsa/conformance/core/traffic/TrafficRecorder.java
@@ -6,6 +6,8 @@ import java.time.Instant;
 import java.util.*;
 import org.dcsa.conformance.core.state.SortedPartitionsNonLockingMap;
 
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+
 public class TrafficRecorder {
   private final SortedPartitionsNonLockingMap nonLockingMap;
   private final String partitionKey;
@@ -33,7 +35,7 @@ public class TrafficRecorder {
     nonLockingMap.setItemValue(
         partitionKey,
         Instant.now().toString(),
-        new ObjectMapper()
+      STATE_OBJECT_MAPPER
             .createObjectNode()
             .put("scenarioRun", scenarioRun)
             .set("exchange", conformanceExchange.toJson()));

--- a/core/src/main/java/org/dcsa/conformance/core/traffic/TrafficRecorder.java
+++ b/core/src/main/java/org/dcsa/conformance/core/traffic/TrafficRecorder.java
@@ -1,12 +1,11 @@
 package org.dcsa.conformance.core.traffic;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.time.Instant;
 import java.util.*;
 import org.dcsa.conformance.core.state.SortedPartitionsNonLockingMap;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 public class TrafficRecorder {
   private final SortedPartitionsNonLockingMap nonLockingMap;
@@ -35,7 +34,7 @@ public class TrafficRecorder {
     nonLockingMap.setItemValue(
         partitionKey,
         Instant.now().toString(),
-      STATE_OBJECT_MAPPER
+      OBJECT_MAPPER
             .createObjectNode()
             .put("scenarioRun", scenarioRun)
             .set("exchange", conformanceExchange.toJson()));

--- a/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceOrchestrator.java
+++ b/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceOrchestrator.java
@@ -1,7 +1,6 @@
 package org.dcsa.conformance.sandbox;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.*;
@@ -23,7 +22,7 @@ import org.dcsa.conformance.core.state.StatefulEntity;
 import org.dcsa.conformance.core.traffic.*;
 import org.dcsa.conformance.sandbox.configuration.SandboxConfiguration;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 @Slf4j
 public class ConformanceOrchestrator implements StatefulEntity {
@@ -52,7 +51,7 @@ public class ConformanceOrchestrator implements StatefulEntity {
 
   @Override
   public JsonNode exportJsonState() {
-    ObjectNode jsonState = STATE_OBJECT_MAPPER.createObjectNode();
+    ObjectNode jsonState = OBJECT_MAPPER.createObjectNode();
 
     { // scoped
       ArrayNode arrayNode = jsonState.putArray("scenarios");
@@ -100,7 +99,7 @@ public class ConformanceOrchestrator implements StatefulEntity {
   }
 
   public JsonNode getStatus() {
-    ObjectNode statusNode = STATE_OBJECT_MAPPER.createObjectNode();
+    ObjectNode statusNode = OBJECT_MAPPER.createObjectNode();
     statusNode.put(
         "scenariosLeft",
         scenariosById.values().stream().filter(ConformanceScenario::hasNextAction).count());
@@ -172,7 +171,7 @@ public class ConformanceOrchestrator implements StatefulEntity {
   public JsonNode handleGetPartyPrompt(String partyName) {
     log.info("ConformanceOrchestrator.handleGetPartyPrompt(%s)".formatted(partyName));
 
-    ArrayNode partyPrompt = STATE_OBJECT_MAPPER.createArrayNode();
+    ArrayNode partyPrompt = OBJECT_MAPPER.createArrayNode();
     if (currentScenarioId == null) return partyPrompt;
 
     ConformanceAction nextAction = scenariosById.get(currentScenarioId).peekNextAction();
@@ -272,7 +271,7 @@ public class ConformanceOrchestrator implements StatefulEntity {
   }
 
   public ArrayNode getScenarioDigests() {
-    ArrayNode arrayNode = STATE_OBJECT_MAPPER.createArrayNode();
+    ArrayNode arrayNode = OBJECT_MAPPER.createArrayNode();
     if (!sandboxConfiguration.getOrchestrator().isActive()) return arrayNode;
 
     ConformanceCheck conformanceCheck = _createScenarioConformanceCheck();
@@ -295,7 +294,7 @@ public class ConformanceOrchestrator implements StatefulEntity {
               log.info(
                   "Scenario description: '%s'".formatted(scenario.getReportTitleDescription()));
               ObjectNode scenarioNode =
-                STATE_OBJECT_MAPPER
+                OBJECT_MAPPER
                       .createObjectNode()
                       .put("id", scenario.getId().toString())
                       .put("name", scenario.getTitle())
@@ -320,7 +319,7 @@ public class ConformanceOrchestrator implements StatefulEntity {
 
   public ObjectNode getScenarioDigest(String scenarioId) {
     ConformanceScenario scenario = this.scenariosById.get(UUID.fromString(scenarioId));
-    return STATE_OBJECT_MAPPER
+    return OBJECT_MAPPER
         .createObjectNode()
         .put("id", scenario.getId().toString())
         .put("name", scenario.getTitle())
@@ -330,7 +329,7 @@ public class ConformanceOrchestrator implements StatefulEntity {
   public ObjectNode getScenarioStatus(String scenarioId) {
     UUID scenarioUuid = UUID.fromString(scenarioId);
 
-    ObjectNode scenarioNode = STATE_OBJECT_MAPPER.createObjectNode();
+    ObjectNode scenarioNode = OBJECT_MAPPER.createObjectNode();
     UUID runUuid = latestRunIdsByScenarioId.get(scenarioUuid);
     if (runUuid == null) return scenarioNode;
 

--- a/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceSandbox.java
+++ b/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceSandbox.java
@@ -1,7 +1,6 @@
 package org.dcsa.conformance.sandbox;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.net.URI;
@@ -32,7 +31,7 @@ import org.dcsa.conformance.standards.eblsurrender.EblSurrenderComponentFactory;
 import org.dcsa.conformance.standards.ovs.OvsComponentFactory;
 import org.dcsa.conformance.standards.tnt.TntComponentFactory;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 @Slf4j
 public class ConformanceSandbox {
@@ -208,7 +207,7 @@ public class ConformanceSandbox {
       Consumer<JsonNode> deferredSandboxTaskConsumer) {
     log.info(
         "ConformanceSandbox.handleRequest() "
-            + STATE_OBJECT_MAPPER.valueToTree(webRequest).toPrettyString());
+            + OBJECT_MAPPER.valueToTree(webRequest).toPrettyString());
 
     String expectedPrefix = "/conformance/sandbox/";
     int expectedPrefixStart = webRequest.url().indexOf(expectedPrefix);
@@ -309,7 +308,7 @@ public class ConformanceSandbox {
     if (sandboxConfiguration.getOrchestrator().isActive()) return null;
 
     String partyName = sandboxConfiguration.getParties()[0].getName();
-    ArrayNode operatorLogNode = STATE_OBJECT_MAPPER.createArrayNode();
+    ArrayNode operatorLogNode = OBJECT_MAPPER.createArrayNode();
     new PartyTask(
             persistenceProvider,
             deferredSandboxTaskConsumer,
@@ -391,7 +390,7 @@ public class ConformanceSandbox {
       String sandboxId,
       String actionId,
       JsonNode actionInputOrNull) {
-    ObjectNode partyInput = STATE_OBJECT_MAPPER.createObjectNode().put("actionId", actionId);
+    ObjectNode partyInput = OBJECT_MAPPER.createObjectNode().put("actionId", actionId);
     if (actionInputOrNull != null) {
       partyInput.set("input", actionInputOrNull);
     }
@@ -404,7 +403,7 @@ public class ConformanceSandbox {
             "handling in sandbox %s the input for action %s".formatted(sandboxId, actionId),
             orchestrator -> orchestrator.handlePartyInput(partyInput))
         .run();
-    return STATE_OBJECT_MAPPER.createObjectNode();
+    return OBJECT_MAPPER.createObjectNode();
   }
 
   public static JsonNode startOrStopScenario(
@@ -421,7 +420,7 @@ public class ConformanceSandbox {
             "starting in sandbox %s scenario %s".formatted(sandboxId, scenarioId),
             orchestrator -> orchestrator.startOrStopScenario(scenarioId))
         .run();
-    return STATE_OBJECT_MAPPER.createObjectNode();
+    return OBJECT_MAPPER.createObjectNode();
   }
 
   private static ConformanceWebResponse _handlePartyNotification(
@@ -501,7 +500,7 @@ public class ConformanceSandbox {
       String sandboxId,
       ConformanceRequest conformanceRequest) {
     JsonNode deferredTask =
-      STATE_OBJECT_MAPPER
+      OBJECT_MAPPER
             .createObjectNode()
             .put("handler", "_syncHandleOutboundRequest")
             .put("sandboxId", sandboxId)
@@ -513,7 +512,7 @@ public class ConformanceSandbox {
   private static void _asyncSendOutboundWebRequest(
       Consumer<JsonNode> deferredSandboxTaskConsumer, ConformanceWebRequest conformanceWebRequest) {
     JsonNode deferredTask =
-      STATE_OBJECT_MAPPER
+      OBJECT_MAPPER
             .createObjectNode()
             .put("handler", "_syncSendOutboundWebRequest")
             .set("conformanceWebRequest", conformanceWebRequest.toJson());
@@ -736,13 +735,13 @@ public class ConformanceSandbox {
             "sandbox#" + sandboxId,
             "state",
             originalSandboxState ->
-              STATE_OBJECT_MAPPER.createObjectNode().put("currentSessionId", newSessionId));
+              OBJECT_MAPPER.createObjectNode().put("currentSessionId", newSessionId));
     persistenceProvider
         .getNonLockingMap()
         .setItemValue(
             "sandbox#" + sandboxId,
             "SK=session#%s#%s".formatted(Instant.now().toString(), newSessionId),
-          STATE_OBJECT_MAPPER.createObjectNode());
+          OBJECT_MAPPER.createObjectNode());
 
     SandboxConfiguration sandboxConfiguration =
         loadSandboxConfiguration(persistenceProvider, sandboxId);
@@ -776,7 +775,7 @@ public class ConformanceSandbox {
         .setItemValue(
             "environment#" + environmentId,
             "sandbox#" + sandboxConfiguration.getId(),
-          STATE_OBJECT_MAPPER
+          OBJECT_MAPPER
                 .createObjectNode()
                 .put("id", sandboxConfiguration.getId())
                 .put("name", sandboxConfiguration.getName()));

--- a/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceSandbox.java
+++ b/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceSandbox.java
@@ -32,6 +32,8 @@ import org.dcsa.conformance.standards.eblsurrender.EblSurrenderComponentFactory;
 import org.dcsa.conformance.standards.ovs.OvsComponentFactory;
 import org.dcsa.conformance.standards.tnt.TntComponentFactory;
 
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+
 @Slf4j
 public class ConformanceSandbox {
   private record OrchestratorTask(
@@ -206,7 +208,7 @@ public class ConformanceSandbox {
       Consumer<JsonNode> deferredSandboxTaskConsumer) {
     log.info(
         "ConformanceSandbox.handleRequest() "
-            + new ObjectMapper().valueToTree(webRequest).toPrettyString());
+            + STATE_OBJECT_MAPPER.valueToTree(webRequest).toPrettyString());
 
     String expectedPrefix = "/conformance/sandbox/";
     int expectedPrefixStart = webRequest.url().indexOf(expectedPrefix);
@@ -307,7 +309,7 @@ public class ConformanceSandbox {
     if (sandboxConfiguration.getOrchestrator().isActive()) return null;
 
     String partyName = sandboxConfiguration.getParties()[0].getName();
-    ArrayNode operatorLogNode = new ObjectMapper().createArrayNode();
+    ArrayNode operatorLogNode = STATE_OBJECT_MAPPER.createArrayNode();
     new PartyTask(
             persistenceProvider,
             deferredSandboxTaskConsumer,
@@ -389,7 +391,7 @@ public class ConformanceSandbox {
       String sandboxId,
       String actionId,
       JsonNode actionInputOrNull) {
-    ObjectNode partyInput = new ObjectMapper().createObjectNode().put("actionId", actionId);
+    ObjectNode partyInput = STATE_OBJECT_MAPPER.createObjectNode().put("actionId", actionId);
     if (actionInputOrNull != null) {
       partyInput.set("input", actionInputOrNull);
     }
@@ -402,7 +404,7 @@ public class ConformanceSandbox {
             "handling in sandbox %s the input for action %s".formatted(sandboxId, actionId),
             orchestrator -> orchestrator.handlePartyInput(partyInput))
         .run();
-    return new ObjectMapper().createObjectNode();
+    return STATE_OBJECT_MAPPER.createObjectNode();
   }
 
   public static JsonNode startOrStopScenario(
@@ -419,7 +421,7 @@ public class ConformanceSandbox {
             "starting in sandbox %s scenario %s".formatted(sandboxId, scenarioId),
             orchestrator -> orchestrator.startOrStopScenario(scenarioId))
         .run();
-    return new ObjectMapper().createObjectNode();
+    return STATE_OBJECT_MAPPER.createObjectNode();
   }
 
   private static ConformanceWebResponse _handlePartyNotification(
@@ -499,7 +501,7 @@ public class ConformanceSandbox {
       String sandboxId,
       ConformanceRequest conformanceRequest) {
     JsonNode deferredTask =
-        new ObjectMapper()
+      STATE_OBJECT_MAPPER
             .createObjectNode()
             .put("handler", "_syncHandleOutboundRequest")
             .put("sandboxId", sandboxId)
@@ -511,7 +513,7 @@ public class ConformanceSandbox {
   private static void _asyncSendOutboundWebRequest(
       Consumer<JsonNode> deferredSandboxTaskConsumer, ConformanceWebRequest conformanceWebRequest) {
     JsonNode deferredTask =
-        new ObjectMapper()
+      STATE_OBJECT_MAPPER
             .createObjectNode()
             .put("handler", "_syncSendOutboundWebRequest")
             .set("conformanceWebRequest", conformanceWebRequest.toJson());
@@ -734,13 +736,13 @@ public class ConformanceSandbox {
             "sandbox#" + sandboxId,
             "state",
             originalSandboxState ->
-                new ObjectMapper().createObjectNode().put("currentSessionId", newSessionId));
+              STATE_OBJECT_MAPPER.createObjectNode().put("currentSessionId", newSessionId));
     persistenceProvider
         .getNonLockingMap()
         .setItemValue(
             "sandbox#" + sandboxId,
             "SK=session#%s#%s".formatted(Instant.now().toString(), newSessionId),
-            new ObjectMapper().createObjectNode());
+          STATE_OBJECT_MAPPER.createObjectNode());
 
     SandboxConfiguration sandboxConfiguration =
         loadSandboxConfiguration(persistenceProvider, sandboxId);
@@ -774,7 +776,7 @@ public class ConformanceSandbox {
         .setItemValue(
             "environment#" + environmentId,
             "sandbox#" + sandboxConfiguration.getId(),
-            new ObjectMapper()
+          STATE_OBJECT_MAPPER
                 .createObjectNode()
                 .put("id", sandboxConfiguration.getId())
                 .put("name", sandboxConfiguration.getName()));

--- a/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceWebRequest.java
+++ b/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceWebRequest.java
@@ -7,6 +7,8 @@ import java.util.Collection;
 import java.util.Map;
 import org.dcsa.conformance.core.toolkit.JsonToolkit;
 
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+
 public record ConformanceWebRequest(
     String method,
     String url,
@@ -16,7 +18,7 @@ public record ConformanceWebRequest(
 
   public ObjectNode toJson() {
     ObjectNode objectNode =
-        new ObjectMapper()
+      STATE_OBJECT_MAPPER
             .createObjectNode()
             .put("method", method)
             .put("url", url)

--- a/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceWebRequest.java
+++ b/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceWebRequest.java
@@ -1,13 +1,12 @@
 package org.dcsa.conformance.sandbox;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Collection;
 import java.util.Map;
 import org.dcsa.conformance.core.toolkit.JsonToolkit;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 public record ConformanceWebRequest(
     String method,
@@ -18,7 +17,7 @@ public record ConformanceWebRequest(
 
   public ObjectNode toJson() {
     ObjectNode objectNode =
-      STATE_OBJECT_MAPPER
+      OBJECT_MAPPER
             .createObjectNode()
             .put("method", method)
             .put("url", url)

--- a/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceWebuiHandler.java
+++ b/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceWebuiHandler.java
@@ -22,6 +22,8 @@ import org.dcsa.conformance.standards.eblsurrender.EblSurrenderComponentFactory;
 import org.dcsa.conformance.standards.ovs.OvsComponentFactory;
 import org.dcsa.conformance.standards.tnt.TntComponentFactory;
 
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+
 @Slf4j
 public class ConformanceWebuiHandler {
   private final ConformanceAccessChecker accessChecker;
@@ -186,7 +188,7 @@ public class ConformanceWebuiHandler {
 
     log.info("Created sandbox: " + sandboxConfiguration.toJsonNode().toPrettyString());
 
-    return new ObjectMapper().createObjectNode().put("sandboxId", sandboxId);
+    return STATE_OBJECT_MAPPER.createObjectNode().put("sandboxId", sandboxId);
   }
 
   private JsonNode _getSandboxConfig(String userId, JsonNode requestNode) {
@@ -213,7 +215,7 @@ public class ConformanceWebuiHandler {
             .findFirst()
             .orElseThrow();
 
-    return new ObjectMapper()
+    return STATE_OBJECT_MAPPER
         .createObjectNode()
         .put("sandboxId", sandboxConfiguration.getId())
         .put("sandboxName", sandboxConfiguration.getName())
@@ -268,19 +270,18 @@ public class ConformanceWebuiHandler {
 
     log.info("Updated sandbox: " + sandboxConfiguration.toJsonNode().toPrettyString());
 
-    return new ObjectMapper().createObjectNode();
+    return STATE_OBJECT_MAPPER.createObjectNode();
   }
 
   private JsonNode _getAvailableStandards(String ignoredUserId) {
-    ObjectMapper objectMapper = new ObjectMapper();
-    ArrayNode standardsNode = objectMapper.createArrayNode();
+    ArrayNode standardsNode = STATE_OBJECT_MAPPER.createArrayNode();
     TreeSet<String> sortedStandardNames = new TreeSet<>(String::compareToIgnoreCase);
     sortedStandardNames.addAll(componentFactories.keySet());
     sortedStandardNames.forEach(
         standardName -> {
-          ObjectNode standardNode = objectMapper.createObjectNode().put("name", standardName);
+          ObjectNode standardNode = STATE_OBJECT_MAPPER.createObjectNode().put("name", standardName);
           {
-            ArrayNode versionsNode = objectMapper.createArrayNode();
+            ArrayNode versionsNode = STATE_OBJECT_MAPPER.createArrayNode();
             standardNode.set("versions", versionsNode);
             componentFactories
                 .get(standardName)
@@ -288,9 +289,9 @@ public class ConformanceWebuiHandler {
                 .forEach(
                     standardVersion -> {
                       ObjectNode versionNode =
-                          objectMapper.createObjectNode().put("number", standardVersion);
+                        STATE_OBJECT_MAPPER.createObjectNode().put("number", standardVersion);
                       {
-                        ArrayNode rolesNode = objectMapper.createArrayNode();
+                        ArrayNode rolesNode = STATE_OBJECT_MAPPER.createArrayNode();
                         componentFactories
                             .get(standardName)
                             .get(standardVersion)
@@ -315,7 +316,7 @@ public class ConformanceWebuiHandler {
             sandboxNode ->
                 sortedSandboxesByLowercaseName.put(
                     sandboxNode.get("name").asText().toLowerCase(), sandboxNode));
-    ArrayNode sandboxesNode = new ObjectMapper().createArrayNode();
+    ArrayNode sandboxesNode = STATE_OBJECT_MAPPER.createArrayNode();
     sortedSandboxesByLowercaseName.values().forEach(sandboxesNode::add);
     return sandboxesNode;
   }
@@ -346,14 +347,14 @@ public class ConformanceWebuiHandler {
     String sandboxId = requestNode.get("sandboxId").asText();
     accessChecker.checkUserSandboxAccess(userId, sandboxId);
     ConformanceSandbox.notifyParty(persistenceProvider, deferredSandboxTaskConsumer, sandboxId);
-    return new ObjectMapper().createObjectNode();
+    return STATE_OBJECT_MAPPER.createObjectNode();
   }
 
   private JsonNode _resetParty(String userId, JsonNode requestNode) {
     String sandboxId = requestNode.get("sandboxId").asText();
     accessChecker.checkUserSandboxAccess(userId, sandboxId);
     ConformanceSandbox.resetParty(persistenceProvider, deferredSandboxTaskConsumer, sandboxId);
-    return new ObjectMapper().createObjectNode();
+    return STATE_OBJECT_MAPPER.createObjectNode();
   }
 
   private JsonNode _getScenarioDigests(String userId, JsonNode requestNode) {

--- a/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceWebuiHandler.java
+++ b/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceWebuiHandler.java
@@ -1,7 +1,6 @@
 package org.dcsa.conformance.sandbox;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.*;
@@ -22,7 +21,7 @@ import org.dcsa.conformance.standards.eblsurrender.EblSurrenderComponentFactory;
 import org.dcsa.conformance.standards.ovs.OvsComponentFactory;
 import org.dcsa.conformance.standards.tnt.TntComponentFactory;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 @Slf4j
 public class ConformanceWebuiHandler {
@@ -188,7 +187,7 @@ public class ConformanceWebuiHandler {
 
     log.info("Created sandbox: " + sandboxConfiguration.toJsonNode().toPrettyString());
 
-    return STATE_OBJECT_MAPPER.createObjectNode().put("sandboxId", sandboxId);
+    return OBJECT_MAPPER.createObjectNode().put("sandboxId", sandboxId);
   }
 
   private JsonNode _getSandboxConfig(String userId, JsonNode requestNode) {
@@ -215,7 +214,7 @@ public class ConformanceWebuiHandler {
             .findFirst()
             .orElseThrow();
 
-    return STATE_OBJECT_MAPPER
+    return OBJECT_MAPPER
         .createObjectNode()
         .put("sandboxId", sandboxConfiguration.getId())
         .put("sandboxName", sandboxConfiguration.getName())
@@ -270,18 +269,18 @@ public class ConformanceWebuiHandler {
 
     log.info("Updated sandbox: " + sandboxConfiguration.toJsonNode().toPrettyString());
 
-    return STATE_OBJECT_MAPPER.createObjectNode();
+    return OBJECT_MAPPER.createObjectNode();
   }
 
   private JsonNode _getAvailableStandards(String ignoredUserId) {
-    ArrayNode standardsNode = STATE_OBJECT_MAPPER.createArrayNode();
+    ArrayNode standardsNode = OBJECT_MAPPER.createArrayNode();
     TreeSet<String> sortedStandardNames = new TreeSet<>(String::compareToIgnoreCase);
     sortedStandardNames.addAll(componentFactories.keySet());
     sortedStandardNames.forEach(
         standardName -> {
-          ObjectNode standardNode = STATE_OBJECT_MAPPER.createObjectNode().put("name", standardName);
+          ObjectNode standardNode = OBJECT_MAPPER.createObjectNode().put("name", standardName);
           {
-            ArrayNode versionsNode = STATE_OBJECT_MAPPER.createArrayNode();
+            ArrayNode versionsNode = OBJECT_MAPPER.createArrayNode();
             standardNode.set("versions", versionsNode);
             componentFactories
                 .get(standardName)
@@ -289,9 +288,9 @@ public class ConformanceWebuiHandler {
                 .forEach(
                     standardVersion -> {
                       ObjectNode versionNode =
-                        STATE_OBJECT_MAPPER.createObjectNode().put("number", standardVersion);
+                        OBJECT_MAPPER.createObjectNode().put("number", standardVersion);
                       {
-                        ArrayNode rolesNode = STATE_OBJECT_MAPPER.createArrayNode();
+                        ArrayNode rolesNode = OBJECT_MAPPER.createArrayNode();
                         componentFactories
                             .get(standardName)
                             .get(standardVersion)
@@ -316,7 +315,7 @@ public class ConformanceWebuiHandler {
             sandboxNode ->
                 sortedSandboxesByLowercaseName.put(
                     sandboxNode.get("name").asText().toLowerCase(), sandboxNode));
-    ArrayNode sandboxesNode = STATE_OBJECT_MAPPER.createArrayNode();
+    ArrayNode sandboxesNode = OBJECT_MAPPER.createArrayNode();
     sortedSandboxesByLowercaseName.values().forEach(sandboxesNode::add);
     return sandboxesNode;
   }
@@ -347,14 +346,14 @@ public class ConformanceWebuiHandler {
     String sandboxId = requestNode.get("sandboxId").asText();
     accessChecker.checkUserSandboxAccess(userId, sandboxId);
     ConformanceSandbox.notifyParty(persistenceProvider, deferredSandboxTaskConsumer, sandboxId);
-    return STATE_OBJECT_MAPPER.createObjectNode();
+    return OBJECT_MAPPER.createObjectNode();
   }
 
   private JsonNode _resetParty(String userId, JsonNode requestNode) {
     String sandboxId = requestNode.get("sandboxId").asText();
     accessChecker.checkUserSandboxAccess(userId, sandboxId);
     ConformanceSandbox.resetParty(persistenceProvider, deferredSandboxTaskConsumer, sandboxId);
-    return STATE_OBJECT_MAPPER.createObjectNode();
+    return OBJECT_MAPPER.createObjectNode();
   }
 
   private JsonNode _getScenarioDigests(String userId, JsonNode requestNode) {

--- a/sandbox/src/main/java/org/dcsa/conformance/sandbox/configuration/SandboxConfiguration.java
+++ b/sandbox/src/main/java/org/dcsa/conformance/sandbox/configuration/SandboxConfiguration.java
@@ -9,6 +9,8 @@ import lombok.ToString;
 import org.dcsa.conformance.core.party.CounterpartConfiguration;
 import org.dcsa.conformance.core.party.PartyConfiguration;
 
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+
 @Getter
 @Setter
 @ToString
@@ -23,11 +25,11 @@ public class SandboxConfiguration {
   private CounterpartConfiguration[] counterparts;
 
   public JsonNode toJsonNode() {
-    return new ObjectMapper().valueToTree(this);
+    return STATE_OBJECT_MAPPER.valueToTree(this);
   }
 
   @SneakyThrows
   public static SandboxConfiguration fromJsonNode(JsonNode jsonNode) {
-    return new ObjectMapper().treeToValue(jsonNode, SandboxConfiguration.class);
+    return STATE_OBJECT_MAPPER.treeToValue(jsonNode, SandboxConfiguration.class);
   }
 }

--- a/sandbox/src/main/java/org/dcsa/conformance/sandbox/configuration/SandboxConfiguration.java
+++ b/sandbox/src/main/java/org/dcsa/conformance/sandbox/configuration/SandboxConfiguration.java
@@ -1,7 +1,6 @@
 package org.dcsa.conformance.sandbox.configuration;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.SneakyThrows;
@@ -9,7 +8,7 @@ import lombok.ToString;
 import org.dcsa.conformance.core.party.CounterpartConfiguration;
 import org.dcsa.conformance.core.party.PartyConfiguration;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 @Getter
 @Setter
@@ -25,11 +24,11 @@ public class SandboxConfiguration {
   private CounterpartConfiguration[] counterparts;
 
   public JsonNode toJsonNode() {
-    return STATE_OBJECT_MAPPER.valueToTree(this);
+    return OBJECT_MAPPER.valueToTree(this);
   }
 
   @SneakyThrows
   public static SandboxConfiguration fromJsonNode(JsonNode jsonNode) {
-    return STATE_OBJECT_MAPPER.treeToValue(jsonNode, SandboxConfiguration.class);
+    return OBJECT_MAPPER.treeToValue(jsonNode, SandboxConfiguration.class);
   }
 }

--- a/spring-boot/src/main/java/org/dcsa/conformance/springboot/ConformanceApplication.java
+++ b/spring-boot/src/main/java/org/dcsa/conformance/springboot/ConformanceApplication.java
@@ -42,6 +42,8 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.*;
 
+import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+
 @Slf4j
 @RestController
 @SpringBootApplication
@@ -76,7 +78,7 @@ public class ConformanceApplication {
     log.info(
         "new ConformanceApplication(%s)"
             .formatted(
-                new ObjectMapper()
+              STATE_OBJECT_MAPPER
                     .valueToTree(Objects.requireNonNull(this.conformanceConfiguration))
                     .toPrettyString()));
 

--- a/spring-boot/src/main/java/org/dcsa/conformance/springboot/ConformanceApplication.java
+++ b/spring-boot/src/main/java/org/dcsa/conformance/springboot/ConformanceApplication.java
@@ -1,7 +1,6 @@
 package org.dcsa.conformance.springboot;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
@@ -42,7 +41,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.*;
 
-import static org.dcsa.conformance.core.Util.STATE_OBJECT_MAPPER;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 @Slf4j
 @RestController
@@ -78,7 +77,7 @@ public class ConformanceApplication {
     log.info(
         "new ConformanceApplication(%s)"
             .formatted(
-              STATE_OBJECT_MAPPER
+              OBJECT_MAPPER
                     .valueToTree(Objects.requireNonNull(this.conformanceConfiguration))
                     .toPrettyString()));
 


### PR DESCRIPTION
In a single `auto` run for eBL, the `new ObjectMapper()` was profiled to take ~60s CPU time (across all threads).  This change sadly does not translate directly into a ~60s wall time improvement.

However, it is was trivial to fix and remove the `new ObjectMapper()` line from the profiling.