### PR TITLE
DT-862 [2/2]: Add abuse-cases test scenarios to eBL

### DIFF
--- a/core/src/main/java/org/dcsa/conformance/core/party/ActionPromptsQueue.java
+++ b/core/src/main/java/org/dcsa/conformance/core/party/ActionPromptsQueue.java
@@ -34,7 +34,12 @@ public class ActionPromptsQueue implements StatefulEntity {
   }
 
   synchronized JsonNode removeFirst() {
-    return pendingActions.isEmpty() ? null : pendingActions.removeFirst();
+    if (pendingActions.isEmpty()) {
+      return null;
+    }
+    JsonNode actionPrompt = pendingActions.removeFirst();
+    allActionIds.remove(actionPrompt.get("actionId").asText());
+    return actionPrompt;
   }
 
   @Override

--- a/core/src/main/java/org/dcsa/conformance/core/party/ConformanceParty.java
+++ b/core/src/main/java/org/dcsa/conformance/core/party/ConformanceParty.java
@@ -42,7 +42,7 @@ public abstract class ConformanceParty implements StatefulEntity {
   private final Map<String, ? extends Collection<String>> orchestratorAuthHeader;
   private final ActionPromptsQueue actionPromptsQueue = new ActionPromptsQueue();
 
-  private static final int MAX_OPERATOR_LOG_RECORDS = 100;
+  private static final int MAX_OPERATOR_LOG_RECORDS = 10;
   private final LinkedList<String> operatorLog = new LinkedList<>();
 
   protected ConformanceParty(

--- a/core/src/main/java/org/dcsa/conformance/core/scenario/ConformanceScenario.java
+++ b/core/src/main/java/org/dcsa/conformance/core/scenario/ConformanceScenario.java
@@ -20,13 +20,14 @@ import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 @Slf4j
 public class ConformanceScenario implements StatefulEntity {
   @Getter private final String title;
-  @Getter protected UUID id = UUID.randomUUID();
+  @Getter protected UUID id;
   protected final LinkedList<ConformanceAction> allActions = new LinkedList<>();
   protected final LinkedList<ConformanceAction> nextActions = new LinkedList<>();
 
   @Getter private ConformanceStatus latestComputedStatus = ConformanceStatus.NO_TRAFFIC;
 
-  public ConformanceScenario(Collection<ConformanceAction> actions) {
+  public ConformanceScenario(UUID id, Collection<ConformanceAction> actions) {
+    this.id = id;
     this.allActions.addAll(actions);
     this.nextActions.addAll(actions);
     this.title = allActions.isEmpty() ? "" : allActions.peekLast().getActionPath();

--- a/core/src/main/java/org/dcsa/conformance/core/scenario/ScenarioListBuilder.java
+++ b/core/src/main/java/org/dcsa/conformance/core/scenario/ScenarioListBuilder.java
@@ -3,6 +3,8 @@ package org.dcsa.conformance.core.scenario;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +29,7 @@ public abstract class ScenarioListBuilder<T extends ScenarioListBuilder<T>> {
   }
 
   protected List<ConformanceScenario> _buildScenarioList() {
+    AtomicInteger nextScenarioIndex = new AtomicInteger();
     return parent != null
         ? parent._buildScenarioList()
         : asBuilderListList().stream()
@@ -39,7 +42,8 @@ public abstract class ScenarioListBuilder<T extends ScenarioListBuilder<T>> {
                           builder ->
                               actionList.addLast(
                                   builder.actionBuilder.apply(actionList.peekLast())));
-                  return new ConformanceScenario(actionList);
+                  return new ConformanceScenario(
+                      new UUID(0, nextScenarioIndex.getAndIncrement()), actionList);
                 })
             .toList();
   }

--- a/core/src/main/java/org/dcsa/conformance/core/state/StatefulExecutor.java
+++ b/core/src/main/java/org/dcsa/conformance/core/state/StatefulExecutor.java
@@ -45,6 +45,12 @@ public class StatefulExecutor {
         log.info(
             "Max saved state length is now: %d"
                 .formatted(maxStateLength.accumulateAndGet(stateLength, Math::max)));
+        if (stateLength > 100 * 1000) {
+          log.error(
+              "A saved state of size '%d' is too large: %s"
+                  .formatted(stateLength, modifiedState.toPrettyString()));
+          throw new IllegalArgumentException("Saved state is too large");
+        }
       }
     } else {
       sortedPartitionsLockingMap.unlockItem(lockedBy, partitionKey, sortKey);

--- a/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceSandbox.java
+++ b/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceSandbox.java
@@ -63,6 +63,10 @@ public class ConformanceSandbox {
                         componentFactory,
                         new TrafficRecorder(
                             persistenceProvider.getNonLockingMap(), "session#" + currentSessionId),
+                        new JsonNodeMap(
+                            persistenceProvider.getNonLockingMap(),
+                            "session#" + currentSessionId,
+                            "map#orchestrator#"),
                         asyncWebClient);
                 if (originalOrchestratorState != null && !originalOrchestratorState.isEmpty()) {
                   orchestrator.importJsonState(originalOrchestratorState);
@@ -500,7 +504,7 @@ public class ConformanceSandbox {
       String sandboxId,
       ConformanceRequest conformanceRequest) {
     JsonNode deferredTask =
-      OBJECT_MAPPER
+        OBJECT_MAPPER
             .createObjectNode()
             .put("handler", "_syncHandleOutboundRequest")
             .put("sandboxId", sandboxId)
@@ -512,7 +516,7 @@ public class ConformanceSandbox {
   private static void _asyncSendOutboundWebRequest(
       Consumer<JsonNode> deferredSandboxTaskConsumer, ConformanceWebRequest conformanceWebRequest) {
     JsonNode deferredTask =
-      OBJECT_MAPPER
+        OBJECT_MAPPER
             .createObjectNode()
             .put("handler", "_syncSendOutboundWebRequest")
             .set("conformanceWebRequest", conformanceWebRequest.toJson());
@@ -544,7 +548,8 @@ public class ConformanceSandbox {
     } catch (Exception e) {
       log.error(
           "Deferred task execution failed: %s"
-              .formatted(jsonNode == null ? null : jsonNode.toPrettyString()), e);
+              .formatted(jsonNode == null ? null : jsonNode.toPrettyString()),
+          e);
     }
   }
 
@@ -735,13 +740,13 @@ public class ConformanceSandbox {
             "sandbox#" + sandboxId,
             "state",
             originalSandboxState ->
-              OBJECT_MAPPER.createObjectNode().put("currentSessionId", newSessionId));
+                OBJECT_MAPPER.createObjectNode().put("currentSessionId", newSessionId));
     persistenceProvider
         .getNonLockingMap()
         .setItemValue(
             "sandbox#" + sandboxId,
             "SK=session#%s#%s".formatted(Instant.now().toString(), newSessionId),
-          OBJECT_MAPPER.createObjectNode());
+            OBJECT_MAPPER.createObjectNode());
 
     SandboxConfiguration sandboxConfiguration =
         loadSandboxConfiguration(persistenceProvider, sandboxId);
@@ -775,7 +780,7 @@ public class ConformanceSandbox {
         .setItemValue(
             "environment#" + environmentId,
             "sandbox#" + sandboxConfiguration.getId(),
-          OBJECT_MAPPER
+            OBJECT_MAPPER
                 .createObjectNode()
                 .put("id", sandboxConfiguration.getId())
                 .put("name", sandboxConfiguration.getName()));


### PR DESCRIPTION
Note: Locally I had to tweak the `MemorySortedPartitionsLockingMap` time outs to view the report. I have not included the changes to these time outs, because I feel it is the wrong solution. Loading the report should not take that long.
