### PR TITLE
Refactor conformance scenario creation

### DIFF
--- a/core/src/main/java/org/dcsa/conformance/core/scenario/ConformanceScenario.java
+++ b/core/src/main/java/org/dcsa/conformance/core/scenario/ConformanceScenario.java
@@ -26,6 +26,10 @@ public class ConformanceScenario implements StatefulEntity {
 
   @Getter private ConformanceStatus latestComputedStatus = ConformanceStatus.NO_TRAFFIC;
 
+  public ConformanceScenario(long moduleIndex, long scenarioIndex, Collection<ConformanceAction> actions) {
+    this(new UUID(moduleIndex, scenarioIndex), actions);
+  }
+
   public ConformanceScenario(UUID id, Collection<ConformanceAction> actions) {
     this.id = id;
     this.allActions.addAll(actions);

--- a/core/src/main/java/org/dcsa/conformance/core/scenario/ScenarioListBuilder.java
+++ b/core/src/main/java/org/dcsa/conformance/core/scenario/ScenarioListBuilder.java
@@ -42,8 +42,7 @@ public abstract class ScenarioListBuilder<T extends ScenarioListBuilder<T>> {
                           builder ->
                               actionList.addLast(
                                   builder.actionBuilder.apply(actionList.peekLast())));
-                  return new ConformanceScenario(
-                      new UUID(moduleIndex, nextScenarioIndex.getAndIncrement()), actionList);
+                  return new ConformanceScenario(moduleIndex, nextScenarioIndex.getAndIncrement(), actionList);
                 })
             .toList();
   }


### PR DESCRIPTION
Move the `ConformanceScenario` creation into the `AbstractComponantFactory` and reduce visbility of `createModuleScenarioListBuilders`. This will enable us to use different scenarion creation methods for different standards.

In the `ConformanceOrchestrator`, reduce the typing of `scenariosByModuleName` to `List<ConformanceScenario>` from `ArrayList<...>`. The actual list is not used externally and internally the orchestrator will always just iterate over it via stream or for-each loops. Given there is no "random access" accessing, then any `List`-type will do. This in turn will enable more flexibility for the scenarion building code to choose which list is used.