### PR TITLE
Generic projects updates

### DIFF
--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/model/PersistableCarrierBooking.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/model/PersistableCarrierBooking.java
@@ -1,13 +1,12 @@
 package org.dcsa.conformance.standards.booking.model;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 import static org.dcsa.conformance.standards.booking.party.BookingCancellationState.*;
 import static org.dcsa.conformance.standards.booking.party.BookingState.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -15,7 +14,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.StreamSupport;
-
 import org.dcsa.conformance.core.state.JsonNodeMap;
 import org.dcsa.conformance.standards.booking.party.BookingCancellationState;
 import org.dcsa.conformance.standards.booking.party.BookingState;
@@ -79,7 +77,6 @@ public class PersistableCarrierBooking {
   private static final String BOOKING_DATA_FIELD = "booking";
   private static final String AMENDED_BOOKING_DATA_FIELD = "amendedBooking";
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private final ObjectNode state;
 
   private PersistableCarrierBooking(ObjectNode state) {
@@ -191,9 +188,7 @@ public class PersistableCarrierBooking {
       rejectReason = "default message of rejection(reason not provided by carrier)";
     }
     final var reason = rejectReason;
-    mutateBookingAndAmendment((bookingContent, isAmendedContent) -> {
-      bookingContent.put("reason", reason);
-    });
+    mutateBookingAndAmendment((bookingContent, isAmendedContent) -> bookingContent.put("reason", reason));
   }
 
   public void confirmBookingCompleted(String reference, boolean resetAmendedBooking) {

--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/party/BookingCarrier.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/party/BookingCarrier.java
@@ -1,7 +1,8 @@
 package org.dcsa.conformance.standards.booking.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.time.Instant;
 import java.util.*;
@@ -22,8 +23,6 @@ import org.dcsa.conformance.core.traffic.ConformanceResponse;
 import org.dcsa.conformance.standards.booking.action.*;
 import org.dcsa.conformance.standards.booking.checks.ScenarioType;
 import org.dcsa.conformance.standards.booking.model.PersistableCarrierBooking;
-
-import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 @Slf4j
 public class BookingCarrier extends ConformanceParty {
@@ -57,8 +56,8 @@ public class BookingCarrier extends ConformanceParty {
 
   @Override
   protected void exportPartyJsonState(ObjectNode targetObjectNode) {
-    targetObjectNode.set("cbrrToCbr", StateManagementUtil.storeMap(OBJECT_MAPPER, cbrrToCbr));
-    targetObjectNode.set("cbrToCbrr", StateManagementUtil.storeMap(OBJECT_MAPPER, cbrToCbrr));
+    targetObjectNode.set("cbrrToCbr", StateManagementUtil.storeMap(cbrrToCbr));
+    targetObjectNode.set("cbrToCbrr", StateManagementUtil.storeMap(cbrToCbrr));
   }
 
   @Override
@@ -89,18 +88,6 @@ public class BookingCarrier extends ConformanceParty {
         Map.entry(UC10_Carrier_DeclineBookingAction.class, this::declineBooking),
         Map.entry(UC12_Carrier_ConfirmBookingCompletedAction.class, this::confirmBookingCompleted),
         Map.entry(UC14CarrierProcessBookingCancellationAction.class, this::processConfirmedBookingCancellation));
-  }
-
-  private char computeVesselIMONumberCheckDigit(String vesselIMONumberSansCheckDigit) {
-    int sum = 0;
-    assert vesselIMONumberSansCheckDigit.length() == 6;
-    for (int i = 0; i < 6; i++) {
-      char c = vesselIMONumberSansCheckDigit.charAt(i);
-      assert c >= '0' && c <= '9';
-      sum += (7 - i) * Character.getNumericValue(c);
-    }
-    String s = String.valueOf(sum);
-    return s.charAt(s.length() - 1);
   }
 
   private void supplyScenarioParameters(JsonNode actionPrompt) {
@@ -391,7 +378,7 @@ public class BookingCarrier extends ConformanceParty {
     return request.createResponse(
         405,
         Map.of(
-            "Api-Version", List.of(apiVersion), "Allow", List.of(String.join(",", allowedMethods))),
+            API_VERSION, List.of(apiVersion), "Allow", List.of(String.join(",", allowedMethods))),
         new ConformanceMessageBody(
             OBJECT_MAPPER
                 .createObjectNode()
@@ -401,7 +388,7 @@ public class BookingCarrier extends ConformanceParty {
   private ConformanceResponse return400(ConformanceRequest request, String message) {
     return request.createResponse(
         400,
-        Map.of("Api-Version", List.of(apiVersion)),
+        Map.of(API_VERSION, List.of(apiVersion)),
         new ConformanceMessageBody(OBJECT_MAPPER.createObjectNode().put("message", message)));
   }
 
@@ -412,14 +399,14 @@ public class BookingCarrier extends ConformanceParty {
   private ConformanceResponse return404(ConformanceRequest request, String message) {
     return request.createResponse(
         404,
-        Map.of("Api-Version", List.of(apiVersion)),
+        Map.of(API_VERSION, List.of(apiVersion)),
         new ConformanceMessageBody(OBJECT_MAPPER.createObjectNode().put("message", message)));
   }
 
   private ConformanceResponse return409(ConformanceRequest request, String message) {
     return request.createResponse(
         409,
-        Map.of("Api-Version", List.of(apiVersion)),
+        Map.of(API_VERSION, List.of(apiVersion)),
         new ConformanceMessageBody(OBJECT_MAPPER.createObjectNode().put("message", message)));
   }
 
@@ -595,7 +582,7 @@ public class BookingCarrier extends ConformanceParty {
     ConformanceResponse response =
         request.createResponse(
             responseCode,
-            Map.of("Api-Version", List.of(apiVersion)),
+            Map.of(API_VERSION, List.of(apiVersion)),
             new ConformanceMessageBody(statusObject));
     addOperatorLogEntry(
         "Responded %d to %s booking '%s' (resulting state '%s')"
@@ -634,7 +621,7 @@ public class BookingCarrier extends ConformanceParty {
       }
       ConformanceResponse response =
           request.createResponse(
-              200, Map.of("Api-Version", List.of(apiVersion)), new ConformanceMessageBody(body));
+              200, Map.of(API_VERSION, List.of(apiVersion)), new ConformanceMessageBody(body));
       addOperatorLogEntry(
           "Responded to GET booking request '%s' (in state '%s')"
               .formatted(

--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/party/BookingShipper.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/party/BookingShipper.java
@@ -1,7 +1,8 @@
 package org.dcsa.conformance.standards.booking.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.*;
 import java.util.function.Consumer;
@@ -19,8 +20,6 @@ import org.dcsa.conformance.core.traffic.ConformanceResponse;
 import org.dcsa.conformance.standards.booking.action.*;
 import org.dcsa.conformance.standards.booking.checks.ScenarioType;
 import org.dcsa.conformance.standards.booking.model.InvalidBookingMessageType;
-
-import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 @Slf4j
 public class BookingShipper extends ConformanceParty {
@@ -230,7 +229,7 @@ public class BookingShipper extends ConformanceParty {
     ConformanceResponse response =
         request.createResponse(
             204,
-            Map.of("Api-Version", List.of(apiVersion)),
+            Map.of(API_VERSION, List.of(apiVersion)),
             new ConformanceMessageBody(OBJECT_MAPPER.createObjectNode()));
 
     addOperatorLogEntry(

--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/party/CarrierScenarioParameters.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/party/CarrierScenarioParameters.java
@@ -1,7 +1,8 @@
 package org.dcsa.conformance.standards.booking.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public record CarrierScenarioParameters(
@@ -17,7 +18,7 @@ public record CarrierScenarioParameters(
                                         String podUNLocationCode
                                         ) {
   public ObjectNode toJson() {
-    return new ObjectMapper()
+    return OBJECT_MAPPER
         .createObjectNode()
         .put("serviceContractReference", serviceContractReference())
         .put("contractQuotationReference", contractQuotationReference())

--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/party/DynamicScenarioParameters.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/party/DynamicScenarioParameters.java
@@ -1,13 +1,13 @@
 package org.dcsa.conformance.standards.booking.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.function.Function;
 import lombok.NonNull;
 import lombok.With;
 import org.dcsa.conformance.standards.booking.checks.ScenarioType;
-
-import java.util.function.Function;
 
 @With
 public record DynamicScenarioParameters(
@@ -22,7 +22,7 @@ public record DynamicScenarioParameters(
     JsonNode updatedBooking
     ) {
   public ObjectNode toJson() {
-    ObjectNode dspNode = new ObjectMapper().createObjectNode();
+    ObjectNode dspNode = OBJECT_MAPPER.createObjectNode();
     dspNode.put("scenarioType", scenarioType.name());
     if (carrierBookingRequestReference != null) {
       dspNode.put("carrierBookingRequestReference", carrierBookingRequestReference);

--- a/cdk/pom.xml
+++ b/cdk/pom.xml
@@ -33,11 +33,5 @@
 			<version>2.159.1</version>
 			<scope>compile</scope>
 		</dependency>
-		<dependency>
-			<groupId>software.constructs</groupId>
-			<artifactId>constructs</artifactId>
-			<version>10.3.0</version>
-			<scope>compile</scope>
-		</dependency>
 	</dependencies>
 </project>

--- a/commercial-schedules/src/main/java/org/dcsa/conformance/standards/cs/action/CsAction.java
+++ b/commercial-schedules/src/main/java/org/dcsa/conformance/standards/cs/action/CsAction.java
@@ -24,7 +24,7 @@ public abstract class CsAction extends ConformanceAction {
   protected final int expectedStatus;
   private final OverwritingReference<DynamicScenarioParameters> dsp;
 
-  public CsAction(
+  protected CsAction(
       String sourcePartyName,
       String targetPartyName,
       CsAction previousAction,
@@ -100,7 +100,7 @@ public abstract class CsAction extends ConformanceAction {
       byte[] hashBytes = digest.digest(actualResponse.getBytes());
       responseHash = HexFormat.of().formatHex(hashBytes);
     } catch (NoSuchAlgorithmException e) {
-      log.error("Hashing of the response failed." + e);
+      log.error("Hashing of the response failed.", e);
     }
     return responseHash;
   }

--- a/commercial-schedules/src/main/java/org/dcsa/conformance/standards/cs/party/CsPublisher.java
+++ b/commercial-schedules/src/main/java/org/dcsa/conformance/standards/cs/party/CsPublisher.java
@@ -1,7 +1,8 @@
 package org.dcsa.conformance.standards.cs.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.*;
 import java.util.function.Consumer;
@@ -55,7 +56,7 @@ public class CsPublisher extends ConformanceParty {
   public ConformanceResponse handleRequest(ConformanceRequest request) {
     log.info("CsPublisher.handleRequest(%s)".formatted(request));
     String filePath;
-    Map<String, List<String>> initialIMap = Map.of("Api-Version", List.of(apiVersion));
+    Map<String, List<String>> initialIMap = Map.of(API_VERSION, List.of(apiVersion));
     Map<String, Collection<String>> headers = new HashMap<>(initialIMap);
     if (request.queryParams().containsKey("limit")
         && !request.queryParams().containsKey("cursor")) {
@@ -139,7 +140,7 @@ public class CsPublisher extends ConformanceParty {
                             })));
 
     asyncOrchestratorPostPartyInput(
-        new ObjectMapper()
+        OBJECT_MAPPER
             .createObjectNode()
             .put("actionId", actionPrompt.required("actionId").asText())
             .set("input", responseSsp.toJson()));

--- a/commercial-schedules/src/main/java/org/dcsa/conformance/standards/cs/party/DynamicScenarioParameters.java
+++ b/commercial-schedules/src/main/java/org/dcsa/conformance/standards/cs/party/DynamicScenarioParameters.java
@@ -1,7 +1,8 @@
 package org.dcsa.conformance.standards.cs.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.With;
 
@@ -17,7 +18,7 @@ public record DynamicScenarioParameters(String cursor, String firstPage, String 
   }
 
   public ObjectNode toJson() {
-    ObjectNode dspNode = new ObjectMapper().createObjectNode();
+    ObjectNode dspNode = OBJECT_MAPPER.createObjectNode();
     if (cursor != null) {
       dspNode.put("cursor", cursor);
     }

--- a/commercial-schedules/src/main/java/org/dcsa/conformance/standards/cs/party/SuppliedScenarioParameters.java
+++ b/commercial-schedules/src/main/java/org/dcsa/conformance/standards/cs/party/SuppliedScenarioParameters.java
@@ -1,7 +1,8 @@
 package org.dcsa.conformance.standards.cs.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,7 +36,7 @@ public class SuppliedScenarioParameters {
   }
 
   public ObjectNode toJson() {
-    ObjectNode objectNode = new ObjectMapper().createObjectNode();
+    ObjectNode objectNode = OBJECT_MAPPER.createObjectNode();
     map.forEach(
         (csFilterParameter, value) -> objectNode.put(csFilterParameter.getQueryParamName(), value));
     return objectNode;

--- a/core/src/main/java/org/dcsa/conformance/core/check/ApiHeaderCheck.java
+++ b/core/src/main/java/org/dcsa/conformance/core/check/ApiHeaderCheck.java
@@ -3,6 +3,7 @@ package org.dcsa.conformance.core.check;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import org.dcsa.conformance.core.party.ConformanceParty;
 import org.dcsa.conformance.core.traffic.ConformanceExchange;
 import org.dcsa.conformance.core.traffic.HttpMessageType;
 
@@ -47,21 +48,6 @@ public class ApiHeaderCheck extends ActionCheck {
     this("", isRelevantForRoleName, matchedExchangeUuid, httpMessageType, expectedVersion, false);
   }
 
-  public ApiHeaderCheck(
-      String titlePrefix,
-      Predicate<String> isRelevantForRoleName,
-      UUID matchedExchangeUuid,
-      HttpMessageType httpMessageType,
-      String expectedVersion) {
-    this(
-        titlePrefix,
-        isRelevantForRoleName,
-        matchedExchangeUuid,
-        httpMessageType,
-        expectedVersion,
-        false);
-  }
-
   private ApiHeaderCheck(
       String titlePrefix,
       Predicate<String> isRelevantForRoleName,
@@ -71,8 +57,8 @@ public class ApiHeaderCheck extends ActionCheck {
       boolean isNotification) {
     super(
         titlePrefix,
-        "The HTTP %s has a correct Api-Version header"
-            .formatted(httpMessageType.name().toLowerCase()),
+        "The HTTP %s has a correct %s header"
+            .formatted(httpMessageType.name().toLowerCase(), ConformanceParty.API_VERSION),
         isRelevantForRoleName,
         matchedExchangeUuid,
         httpMessageType);
@@ -88,16 +74,16 @@ public class ApiHeaderCheck extends ActionCheck {
         exchange.getMessage(httpMessageType).headers();
     String headerName =
         headers.keySet().stream()
-            .filter(key -> key.equalsIgnoreCase("api-version"))
+            .filter(key -> key.equalsIgnoreCase(ConformanceParty.API_VERSION))
             .findFirst()
-            .orElse("api-version");
+            .orElse(ConformanceParty.API_VERSION);
     Collection<String> headerValues = headers.get(headerName);
     if (headerValues == null || headerValues.isEmpty()) {
       return httpMessageType.equals(HttpMessageType.RESPONSE) && !isNotification
-          ? Set.of("Missing Api-Version header")
+          ? Set.of("Missing %s header".formatted(ConformanceParty.API_VERSION))
           : Collections.emptySet();
     }
-    if (headerValues.size() > 1) return Set.of("Duplicate Api-Version headers");
+    if (headerValues.size() > 1) return Set.of("Duplicate %s headers".formatted(ConformanceParty.API_VERSION));
     String exchangeApiVersion = headerValues.stream().findFirst().orElseThrow();
     if (exchangeApiVersion.contains("-")) {
       exchangeApiVersion = exchangeApiVersion.substring(0, exchangeApiVersion.indexOf("-"));
@@ -132,6 +118,8 @@ public class ApiHeaderCheck extends ActionCheck {
   private Set<String> _checkApiVersionHeaderValue(String expectedValue, String actualValue) {
     return Objects.equals(expectedValue, actualValue)
         ? Set.of()
-        : Set.of("Expected Api-Version '%s' but found '%s'".formatted(expectedValue, actualValue));
+        : Set.of(
+            "Expected %s '%s' but found '%s'"
+                .formatted(ConformanceParty.API_VERSION, expectedValue, actualValue));
   }
 }

--- a/core/src/main/java/org/dcsa/conformance/core/check/JsonSchemaValidator.java
+++ b/core/src/main/java/org/dcsa/conformance/core/check/JsonSchemaValidator.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.*;
-
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -34,8 +33,12 @@ public class JsonSchemaValidator {
 
   @SneakyThrows
   private JsonSchemaValidator(String filePath, String schemaName) {
+    log.info("Loading schema: {} with schemaName: {}", filePath, schemaName);
     // https://github.com/networknt/json-schema-validator/issues/579#issuecomment-1488269135
     InputStream schemaFileInputStream = JsonSchemaValidator.class.getResourceAsStream(filePath);
+    if (schemaFileInputStream == null || schemaFileInputStream.available() == 0) {
+      throw new IllegalArgumentException("Schema file not found: " + filePath);
+    }
     JsonSchemaFactory jsonSchemaFactory =
         JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7))
             .objectMapper(JSON_FACTORY_OBJECT_MAPPER)
@@ -44,6 +47,7 @@ public class JsonSchemaValidator {
     schemaValidatorsConfig.setTypeLoose(false);
     JsonSchema rootJsonSchema =
         jsonSchemaFactory.getSchema(schemaFileInputStream, schemaValidatorsConfig);
+    schemaFileInputStream.close();
     ValidationContext validationContext =
         new ValidationContext(
             jsonSchemaFactory.getUriFactory(),

--- a/core/src/main/java/org/dcsa/conformance/core/party/ConformanceParty.java
+++ b/core/src/main/java/org/dcsa/conformance/core/party/ConformanceParty.java
@@ -88,9 +88,7 @@ public abstract class ConformanceParty implements StatefulEntity {
     return jsonPartyState;
   }
 
-  protected void exportPartyJsonState(ObjectNode targetObjectNode) {
-    // By default, nothing to export. Overwrite if needed
-  }
+  protected abstract void exportPartyJsonState(ObjectNode targetObjectNode);
 
   @Override
   public void importJsonState(JsonNode jsonState) {
@@ -100,9 +98,7 @@ public abstract class ConformanceParty implements StatefulEntity {
     importPartyJsonState((ObjectNode) jsonState);
   }
 
-  protected void importPartyJsonState(ObjectNode sourceObjectNode) {
-    // By default, nothing to import. Overwrite if needed
-  }
+  protected abstract void importPartyJsonState(ObjectNode sourceObjectNode);
 
   protected void addOperatorLogEntry(String logEntry) {
     operatorLog.addFirst(logEntry);

--- a/core/src/main/java/org/dcsa/conformance/core/party/ConformanceParty.java
+++ b/core/src/main/java/org/dcsa/conformance/core/party/ConformanceParty.java
@@ -1,5 +1,7 @@
 package org.dcsa.conformance.core.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -14,7 +16,6 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
 import lombok.Setter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -27,10 +28,10 @@ import org.dcsa.conformance.core.traffic.ConformanceMessageBody;
 import org.dcsa.conformance.core.traffic.ConformanceRequest;
 import org.dcsa.conformance.core.traffic.ConformanceResponse;
 
-import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
-
 @Slf4j
 public abstract class ConformanceParty implements StatefulEntity {
+  public static final String API_VERSION = "Api-Version";
+
   protected final String apiVersion;
   protected final PartyConfiguration partyConfiguration;
   protected final CounterpartConfiguration counterpartConfiguration;
@@ -87,7 +88,9 @@ public abstract class ConformanceParty implements StatefulEntity {
     return jsonPartyState;
   }
 
-  protected abstract void exportPartyJsonState(ObjectNode targetObjectNode);
+  protected void exportPartyJsonState(ObjectNode targetObjectNode) {
+    // By default, nothing to export. Overwrite if needed
+  }
 
   @Override
   public void importJsonState(JsonNode jsonState) {
@@ -97,7 +100,9 @@ public abstract class ConformanceParty implements StatefulEntity {
     importPartyJsonState((ObjectNode) jsonState);
   }
 
-  protected abstract void importPartyJsonState(ObjectNode sourceObjectNode);
+  protected void importPartyJsonState(ObjectNode sourceObjectNode) {
+    // By default, nothing to import. Overwrite if needed
+  }
 
   protected void addOperatorLogEntry(String logEntry) {
     operatorLog.addFirst(logEntry);
@@ -131,8 +136,9 @@ public abstract class ConformanceParty implements StatefulEntity {
   protected void asyncOrchestratorPostPartyInput(JsonNode jsonPartyInput) {
     if (partyConfiguration.isInManualMode()) {
       log.info(
-          "Party %s NOT posting its input automatically (it is in manual mode): %s"
-              .formatted(partyConfiguration.getName(), jsonPartyInput.toPrettyString()));
+          "Party {} NOT posting its input automatically (it is in manual mode): {}",
+          partyConfiguration.getName(),
+          jsonPartyInput.toPrettyString());
       return;
     }
     webClient.asyncRequest(
@@ -193,13 +199,14 @@ public abstract class ConformanceParty implements StatefulEntity {
     } else {
       if (actionId != null) {
         log.info(
-            "Party %s notifying orchestrator that action %s is completed instead of sending notification: no counterpart URL is configured"
-                .formatted(actionId, partyConfiguration.getName()));
+            "Party {} notifying orchestrator that action {} is completed instead of sending notification: no counterpart URL is configured",
+            actionId,
+            partyConfiguration.getName());
         asyncOrchestratorPostPartyInput(OBJECT_MAPPER.createObjectNode().put("actionId", actionId));
       } else {
         log.info(
-            "Party %s NOT sending a notification and NOT notifying orchestrator either: no counterpart URL is configured"
-                .formatted(partyConfiguration.getName()));
+            "Party {} NOT sending a notification and NOT notifying orchestrator either: no counterpart URL is configured",
+            partyConfiguration.getName());
       }
     }
   }
@@ -224,7 +231,7 @@ public abstract class ConformanceParty implements StatefulEntity {
             Stream.concat(
                     Stream.concat(
                         Stream.of(
-                            Map.entry("Api-Version", List.of(apiVersionHeaderValue)),
+                            Map.entry(API_VERSION, List.of(apiVersionHeaderValue)),
                             Map.entry("Content-Type", List.of(JsonToolkit.JSON_UTF_8))),
                         counterpartConfiguration.getAuthHeaderName().isBlank()
                             ? Stream.of()
@@ -251,8 +258,7 @@ public abstract class ConformanceParty implements StatefulEntity {
 
   public void handleNotification() {
     log.info(
-        "%s[%s].handleNotification()"
-            .formatted(getClass().getSimpleName(), partyConfiguration.getName()));
+        "{}[{}].handleNotification()", getClass().getSimpleName(), partyConfiguration.getName());
     JsonNode partyPrompt = _syncGetPartyPrompt();
     if (!partyPrompt.isEmpty()) {
       StreamSupport.stream(partyPrompt.spliterator(), false).forEach(actionPromptsQueue::addLast);
@@ -261,7 +267,7 @@ public abstract class ConformanceParty implements StatefulEntity {
   }
 
   public void reset() {
-    log.info("%s[%s].reset()".formatted(getClass().getSimpleName(), partyConfiguration.getName()));
+    log.info("{}[{}].reset()", getClass().getSimpleName(), partyConfiguration.getName());
     this.actionPromptsQueue.clear();
     this.operatorLog.clear();
     doReset();
@@ -271,9 +277,7 @@ public abstract class ConformanceParty implements StatefulEntity {
 
   @SneakyThrows
   private JsonNode _syncGetPartyPrompt() {
-    log.info(
-        "%s[%s].getPartyPrompt()"
-            .formatted(getClass().getSimpleName(), partyConfiguration.getName()));
+    log.info("{}[{}].getPartyPrompt()", getClass().getSimpleName(), partyConfiguration.getName());
     URI uri =
         URI.create(
             partyConfiguration.getOrchestratorUrl()
@@ -295,11 +299,10 @@ public abstract class ConformanceParty implements StatefulEntity {
     JsonNode actionPrompt = actionPromptsQueue.removeFirst();
     if (actionPrompt == null) return;
     log.info(
-        "%s[%s]._handleNextActionPrompt() handling %s"
-            .formatted(
-                getClass().getSimpleName(),
-                partyConfiguration.getName(),
-                actionPrompt.toPrettyString()));
+        "{}[{}]._handleNextActionPrompt() handling {}",
+        getClass().getSimpleName(),
+        partyConfiguration.getName(),
+        actionPrompt.toPrettyString());
     getActionPromptHandlers().entrySet().stream()
         .filter(
             entry ->

--- a/core/src/main/java/org/dcsa/conformance/core/scenario/ScenarioListBuilder.java
+++ b/core/src/main/java/org/dcsa/conformance/core/scenario/ScenarioListBuilder.java
@@ -3,7 +3,6 @@ package org.dcsa.conformance.core.scenario;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Stream;

--- a/core/src/main/java/org/dcsa/conformance/core/state/StateManagementUtil.java
+++ b/core/src/main/java/org/dcsa/conformance/core/state/StateManagementUtil.java
@@ -1,7 +1,6 @@
 package org.dcsa.conformance.core.state;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -9,19 +8,21 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.StreamSupport;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 public class StateManagementUtil {
 
     private StateManagementUtil() {}
 
-    public static JsonNode storeMap(ObjectMapper objectMapper, Map<String, String> hashMap) {
-        return storeMap(objectMapper, hashMap, Function.identity());
+    public static JsonNode storeMap(Map<String, String> hashMap) {
+        return storeMap(hashMap, Function.identity());
     }
 
-    public static <T> JsonNode storeMap(ObjectMapper objectMapper, Map<String, T> hashMap, Function<T, String> toString) {
-        ArrayNode arrayNode = objectMapper.createArrayNode();
+    public static <T> JsonNode storeMap(Map<String, T> hashMap, Function<T, String> toString) {
+        ArrayNode arrayNode = OBJECT_MAPPER.createArrayNode();
         hashMap.forEach(
                 (key, value) -> {
-                    ObjectNode entryNode = objectMapper.createObjectNode();
+                    ObjectNode entryNode = OBJECT_MAPPER.createObjectNode();
                     entryNode.put("key", key);
                     entryNode.put("value", toString.apply(value));
                     arrayNode.add(entryNode);

--- a/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/party/CarrierScenarioParameters.java
+++ b/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/party/CarrierScenarioParameters.java
@@ -1,14 +1,15 @@
 package org.dcsa.conformance.standards.eblissuance.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public record CarrierScenarioParameters(
   String carrierSigningKeyPEM
   ) {
   public ObjectNode toJson() {
-    return new ObjectMapper()
+    return OBJECT_MAPPER
         .createObjectNode()
         .put("carrierSigningKeyPEM", carrierSigningKeyPEM);
   }

--- a/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/party/DynamicScenarioParameters.java
+++ b/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/party/DynamicScenarioParameters.java
@@ -1,16 +1,17 @@
 package org.dcsa.conformance.standards.eblissuance.party;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.With;
 import org.dcsa.conformance.standards.eblissuance.action.EblType;
+
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 @With
 public record DynamicScenarioParameters(
   EblType eblType) {
   public ObjectNode toJson() {
-    return new ObjectMapper()
+    return OBJECT_MAPPER
         .createObjectNode()
         .put("eblType", eblType.name());
   }

--- a/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/party/EblIssuanceCarrier.java
+++ b/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/party/EblIssuanceCarrier.java
@@ -54,9 +54,9 @@ public class EblIssuanceCarrier extends ConformanceParty {
   protected void exportPartyJsonState(ObjectNode targetObjectNode) {
     targetObjectNode.set(
         "eblStatesByTdr",
-        StateManagementUtil.storeMap(OBJECT_MAPPER, eblStatesByTdr, EblIssuanceState::name));
-    targetObjectNode.set("sirsByTdr", StateManagementUtil.storeMap(OBJECT_MAPPER, sirsByTdr));
-    targetObjectNode.set("brsByTdr", StateManagementUtil.storeMap(OBJECT_MAPPER, brsByTdr));
+        StateManagementUtil.storeMap(eblStatesByTdr, EblIssuanceState::name));
+    targetObjectNode.set("sirsByTdr", StateManagementUtil.storeMap(sirsByTdr));
+    targetObjectNode.set("brsByTdr", StateManagementUtil.storeMap(brsByTdr));
   }
 
   @Override
@@ -208,12 +208,12 @@ public class EblIssuanceCarrier extends ConformanceParty {
 
       return request.createResponse(
           204,
-          Map.of("Api-Version", List.of(apiVersion)),
+          Map.of(API_VERSION, List.of(apiVersion)),
           new ConformanceMessageBody(OBJECT_MAPPER.createObjectNode()));
     } else {
       return request.createResponse(
           409,
-          Map.of("Api-Version", List.of(apiVersion)),
+          Map.of(API_VERSION, List.of(apiVersion)),
           new ConformanceMessageBody(
             OBJECT_MAPPER
                   .createObjectNode()

--- a/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/party/EblIssuancePlatform.java
+++ b/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/party/EblIssuancePlatform.java
@@ -58,8 +58,8 @@ public class EblIssuancePlatform extends ConformanceParty {
         });
     targetObjectNode.set("eblStatesByTdr", arrayNodeEblStatesById);
 
-    targetObjectNode.set("tdr2PendingChecksum", StateManagementUtil.storeMap(OBJECT_MAPPER, tdr2PendingChecksum));
-    targetObjectNode.set("knownChecksums", StateManagementUtil.storeMap(OBJECT_MAPPER, knownChecksums, String::valueOf));
+    targetObjectNode.set("tdr2PendingChecksum", StateManagementUtil.storeMap(tdr2PendingChecksum));
+    targetObjectNode.set("knownChecksums", StateManagementUtil.storeMap(knownChecksums, String::valueOf));
   }
 
   @Override
@@ -166,7 +166,7 @@ public class EblIssuancePlatform extends ConformanceParty {
           .formatted(tdr));
       return request.createResponse(
               400,
-              Map.of("Api-Version", List.of(apiVersion)),
+              Map.of(API_VERSION, List.of(apiVersion)),
               new ConformanceMessageBody(
                 OBJECT_MAPPER
                       .createObjectNode()
@@ -182,7 +182,7 @@ public class EblIssuancePlatform extends ConformanceParty {
       response =
           request.createResponse(
               204,
-              Map.of("Api-Version", List.of(apiVersion)),
+              Map.of(API_VERSION, List.of(apiVersion)),
               new ConformanceMessageBody(OBJECT_MAPPER.createObjectNode()));
     } else {
       String message;
@@ -196,7 +196,7 @@ public class EblIssuancePlatform extends ConformanceParty {
       response =
           request.createResponse(
               409,
-              Map.of("Api-Version", List.of(apiVersion)),
+              Map.of(API_VERSION, List.of(apiVersion)),
               new ConformanceMessageBody(
                 OBJECT_MAPPER
                       .createObjectNode()

--- a/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/party/SuppliedScenarioParameters.java
+++ b/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/party/SuppliedScenarioParameters.java
@@ -1,7 +1,8 @@
 package org.dcsa.conformance.standards.eblissuance.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public record SuppliedScenarioParameters(
@@ -14,7 +15,7 @@ public record SuppliedScenarioParameters(
   String consigneeOrEndorseeCodeListName
   ) {
   public ObjectNode toJson() {
-    return new ObjectMapper()
+    return OBJECT_MAPPER
         .createObjectNode()
         .put("sendToPlatform", sendToPlatform)
         .put("issueToLegalName", issueToLegalName)

--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderCarrier.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderCarrier.java
@@ -1,7 +1,8 @@
 package org.dcsa.conformance.standards.eblsurrender.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.*;
@@ -24,7 +25,6 @@ import org.dcsa.conformance.standards.eblsurrender.action.VoidAndReissueAction;
 @Slf4j
 public class EblSurrenderCarrier extends ConformanceParty {
   private final Map<String, EblSurrenderState> eblStatesById = new HashMap<>();
-  private final ObjectMapper objectMapper = new ObjectMapper();
 
   public EblSurrenderCarrier(
       String apiVersion,
@@ -44,11 +44,10 @@ public class EblSurrenderCarrier extends ConformanceParty {
 
   @Override
   protected void exportPartyJsonState(ObjectNode targetObjectNode) {
-    ObjectMapper objectMapper = new ObjectMapper();
-    ArrayNode arrayNode = objectMapper.createArrayNode();
+    ArrayNode arrayNode = OBJECT_MAPPER.createArrayNode();
     eblStatesById.forEach(
         (key, value) -> {
-          ObjectNode entryNode = objectMapper.createObjectNode();
+          ObjectNode entryNode = OBJECT_MAPPER.createObjectNode();
           entryNode.put("key", key);
           entryNode.put("value", value.name());
           arrayNode.add(entryNode);
@@ -88,10 +87,11 @@ public class EblSurrenderCarrier extends ConformanceParty {
     eblStatesById.put(tdr, EblSurrenderState.AVAILABLE_FOR_SURRENDER);
 
     SuppliedScenarioParameters suppliedScenarioParameters =
-        new SuppliedScenarioParameters(tdr, "XMPL",  "Example carrier party code", "Example party code", "Example code list");
+        new SuppliedScenarioParameters(
+            tdr, "XMPL", "Example carrier party code", "Example party code", "Example code list");
 
     asyncOrchestratorPostPartyInput(
-        objectMapper
+        OBJECT_MAPPER
             .createObjectNode()
             .put("actionId", actionPrompt.required("actionId").asText())
             .set("input", suppliedScenarioParameters.toJson()));
@@ -111,7 +111,7 @@ public class EblSurrenderCarrier extends ConformanceParty {
     }
     eblStatesById.put(tdr, EblSurrenderState.AVAILABLE_FOR_SURRENDER);
     asyncOrchestratorPostPartyInput(
-        objectMapper.createObjectNode().put("actionId", actionPrompt.get("actionId").asText()));
+        OBJECT_MAPPER.createObjectNode().put("actionId", actionPrompt.get("actionId").asText()));
     addOperatorLogEntry(
         "Voided and reissued the eBL with transportDocumentReference '%s'".formatted(tdr));
   }
@@ -141,7 +141,7 @@ public class EblSurrenderCarrier extends ConformanceParty {
     }
     syncCounterpartPost(
         "/v%s/ebl-surrender-responses".formatted(apiVersion.charAt(0)),
-        objectMapper
+        OBJECT_MAPPER
             .createObjectNode()
             .put("surrenderRequestReference", srr)
             .put("action", accept ? "SURR" : "SREJ"));
@@ -179,18 +179,18 @@ public class EblSurrenderCarrier extends ConformanceParty {
 
       return request.createResponse(
           204,
-          Map.of("Api-Version", List.of(apiVersion)),
+          Map.of(API_VERSION, List.of(apiVersion)),
           new ConformanceMessageBody(
-              objectMapper
+              OBJECT_MAPPER
                   .createObjectNode()
                   .put("surrenderRequestReference", srr)
                   .put("transportDocumentReference", tdr)));
     } else {
       return request.createResponse(
           409,
-          Map.of("Api-Version", List.of(apiVersion)),
+          Map.of(API_VERSION, List.of(apiVersion)),
           new ConformanceMessageBody(
-              objectMapper
+              OBJECT_MAPPER
                   .createObjectNode()
                   .put(
                       "comments",

--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderPlatform.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderPlatform.java
@@ -1,7 +1,8 @@
 package org.dcsa.conformance.standards.eblsurrender.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.time.Instant;
 import java.util.*;
@@ -24,7 +25,6 @@ import org.dcsa.conformance.standards.eblsurrender.action.SurrenderRequestAction
 public class EblSurrenderPlatform extends ConformanceParty {
   private final Map<String, EblSurrenderState> eblStatesById = new HashMap<>();
   private final Map<String, String> tdrsBySrr = new HashMap<>();
-  private final ObjectMapper objectMapper = new ObjectMapper();
 
   public EblSurrenderPlatform(
       String apiVersion,
@@ -46,8 +46,8 @@ public class EblSurrenderPlatform extends ConformanceParty {
   protected void exportPartyJsonState(ObjectNode targetObjectNode) {
     targetObjectNode.set(
         "eblStatesById",
-        StateManagementUtil.storeMap(objectMapper, eblStatesById, EblSurrenderState::name));
-    targetObjectNode.set("tdrsBySrr", StateManagementUtil.storeMap(objectMapper, tdrsBySrr));
+        StateManagementUtil.storeMap(eblStatesById, EblSurrenderState::name));
+    targetObjectNode.set("tdrsBySrr", StateManagementUtil.storeMap(tdrsBySrr));
   }
 
   @Override
@@ -125,8 +125,8 @@ public class EblSurrenderPlatform extends ConformanceParty {
       response =
           request.createResponse(
               204,
-              Map.of("Api-Version", List.of(apiVersion)),
-              new ConformanceMessageBody(objectMapper.createObjectNode()));
+              Map.of(API_VERSION, List.of(apiVersion)),
+              new ConformanceMessageBody(OBJECT_MAPPER.createObjectNode()));
     } else if (Objects.equals(
         EblSurrenderState.DELIVERY_SURRENDER_REQUESTED, eblStatesById.get(tdr))) {
       eblStatesById.put(
@@ -137,15 +137,15 @@ public class EblSurrenderPlatform extends ConformanceParty {
       response =
           request.createResponse(
               204,
-              Map.of("Api-Version", List.of(apiVersion)),
-              new ConformanceMessageBody(objectMapper.createObjectNode()));
+              Map.of(API_VERSION, List.of(apiVersion)),
+              new ConformanceMessageBody(OBJECT_MAPPER.createObjectNode()));
     } else {
       response =
           request.createResponse(
               409,
-              Map.of("Api-Version", List.of(apiVersion)),
+              Map.of(API_VERSION, List.of(apiVersion)),
               new ConformanceMessageBody(
-                  objectMapper
+                  OBJECT_MAPPER
                       .createObjectNode()
                       .put(
                           "comments",

--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/SuppliedScenarioParameters.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/SuppliedScenarioParameters.java
@@ -1,13 +1,14 @@
 package org.dcsa.conformance.standards.eblsurrender.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public record SuppliedScenarioParameters(
         String transportDocumentReference, String eblPlatform, String carrierPartyCode, String surrenderPartyCode, String codeListName) {
   public ObjectNode toJson() {
-    return new ObjectMapper()
+    return OBJECT_MAPPER
         .createObjectNode()
         .put("transportDocumentReference", transportDocumentReference)
         .put("eblPlatform", eblPlatform)

--- a/ebl/pom.xml
+++ b/ebl/pom.xml
@@ -26,7 +26,7 @@
 		<dependency>
 			<groupId>com.nimbusds</groupId>
 			<artifactId>nimbus-jose-jwt</artifactId>
-			<version>9.24.4</version>
+			<version>9.41.1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.setl</groupId>

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EBLChecks.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EBLChecks.java
@@ -740,7 +740,7 @@ public class EBLChecks {
       for (var node : nodes) {
         pathBuilder.setLength(contextPath.length());
         pathBuilder.append('[').append(index).append(']');
-        var refPath = pathBuilder.toString() + "." + referenceAttributeName;
+        var refPath = pathBuilder + "." + referenceAttributeName;
         var valueNode = resolveValue != null ? resolveValue.apply(node, pathBuilder) : node;
         index++;
         if (valueNode == null || !valueNode.isTextual()) {

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/ToStringComparator.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/ToStringComparator.java
@@ -54,6 +54,6 @@ public class ToStringComparator implements Comparator<JsonNode> {
         builder.append("}");
       }
       default -> builder.append(node);
-    };
+    }
   }
 }

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/party/EblCarrier.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/party/EblCarrier.java
@@ -1,10 +1,10 @@
 package org.dcsa.conformance.standards.ebl.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 import static org.dcsa.conformance.standards.ebl.checks.EBLChecks.SI_ARRAY_ORDER_DEFINITIONS;
 import static org.dcsa.conformance.standards.ebl.party.EblShipper.siFromScenarioType;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.time.Instant;
 import java.util.*;
@@ -30,7 +30,6 @@ import org.dcsa.conformance.standards.ebl.models.CarrierShippingInstructions;
 
 @Slf4j
 public class EblCarrier extends ConformanceParty {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private final Map<String, String> tdrToSir = new HashMap<>();
 
   public EblCarrier(
@@ -51,7 +50,7 @@ public class EblCarrier extends ConformanceParty {
 
   @Override
   protected void exportPartyJsonState(ObjectNode targetObjectNode) {
-    targetObjectNode.set("tdrToSir", StateManagementUtil.storeMap(OBJECT_MAPPER, tdrToSir));
+    targetObjectNode.set("tdrToSir", StateManagementUtil.storeMap(tdrToSir));
   }
 
   @Override
@@ -451,7 +450,7 @@ public class EblCarrier extends ConformanceParty {
     return request.createResponse(
       405,
       Map.of(
-        "Api-Version", List.of(apiVersion), "Allow", List.of(String.join(",", allowedMethods))),
+        API_VERSION, List.of(apiVersion), "Allow", List.of(String.join(",", allowedMethods))),
       new ConformanceMessageBody(
         OBJECT_MAPPER
           .createObjectNode()
@@ -461,7 +460,7 @@ public class EblCarrier extends ConformanceParty {
   private ConformanceResponse return400(ConformanceRequest request, String message) {
     return request.createResponse(
       400,
-      Map.of("Api-Version", List.of(apiVersion)),
+      Map.of(API_VERSION, List.of(apiVersion)),
       new ConformanceMessageBody(OBJECT_MAPPER.createObjectNode().put("message", message)));
   }
 
@@ -471,7 +470,7 @@ public class EblCarrier extends ConformanceParty {
   private ConformanceResponse return404(ConformanceRequest request, String message) {
     return request.createResponse(
       404,
-      Map.of("Api-Version", List.of(apiVersion)),
+      Map.of(API_VERSION, List.of(apiVersion)),
       new ConformanceMessageBody(
         OBJECT_MAPPER
           .createObjectNode()
@@ -481,7 +480,7 @@ public class EblCarrier extends ConformanceParty {
   private ConformanceResponse return409(ConformanceRequest request, String message) {
     return request.createResponse(
       409,
-      Map.of("Api-Version", List.of(apiVersion)),
+      Map.of(API_VERSION, List.of(apiVersion)),
       new ConformanceMessageBody(OBJECT_MAPPER.createObjectNode().put("message", message)));
   }
 
@@ -528,7 +527,7 @@ public class EblCarrier extends ConformanceParty {
       ConformanceResponse response =
         request.createResponse(
           200,
-          Map.of("Api-Version", List.of(apiVersion)),
+          Map.of(API_VERSION, List.of(apiVersion)),
           new ConformanceMessageBody(body));
       addOperatorLogEntry(
         "Responded to GET shipping instructions request '%s' (in state '%s')"
@@ -554,7 +553,7 @@ public class EblCarrier extends ConformanceParty {
     ConformanceResponse response =
       request.createResponse(
         200,
-        Map.of("Api-Version", List.of(apiVersion)),
+        Map.of(API_VERSION, List.of(apiVersion)),
         new ConformanceMessageBody(body));
     addOperatorLogEntry(
       "Responded to GET transport document request '%s' (in state '%s')"
@@ -635,7 +634,7 @@ public class EblCarrier extends ConformanceParty {
     ConformanceResponse response =
       request.createResponse(
         responseCode,
-        Map.of("Api-Version", List.of(apiVersion)),
+        Map.of(API_VERSION, List.of(apiVersion)),
         new ConformanceMessageBody(statusObject));
     addOperatorLogEntry(
       "Responded %d to %s SI '%s' (resulting state '%s')"
@@ -649,7 +648,7 @@ public class EblCarrier extends ConformanceParty {
     ConformanceResponse response =
       request.createResponse(
         202,
-        Map.of("Api-Version", List.of(apiVersion)),
+        Map.of(API_VERSION, List.of(apiVersion)),
         new ConformanceMessageBody(""));
     addOperatorLogEntry(
       "Responded %d to %s SI '%s' (resulting state '%s')"
@@ -670,7 +669,7 @@ public class EblCarrier extends ConformanceParty {
     ConformanceResponse response =
       request.createResponse(
         responseCode,
-        Map.of("Api-Version", List.of(apiVersion)),
+        Map.of(API_VERSION, List.of(apiVersion)),
         new ConformanceMessageBody(statusObject));
     addOperatorLogEntry(
       "Responded %d to %s TD '%s' (resulting state '%s')"

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/party/EblShipper.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/party/EblShipper.java
@@ -256,7 +256,7 @@ public class EblShipper extends ConformanceParty {
     ConformanceResponse response =
         request.createResponse(
             204,
-            Map.of("Api-Version", List.of(apiVersion)),
+            Map.of(API_VERSION, List.of(apiVersion)),
             new ConformanceMessageBody(OBJECT_MAPPER.createObjectNode()));
 
     addOperatorLogEntry(

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitPublisher.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitPublisher.java
@@ -1,7 +1,8 @@
 package org.dcsa.conformance.standards.jit.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -90,7 +91,7 @@ public class JitPublisher extends ConformanceParty {
                             })));
 
     asyncOrchestratorPostPartyInput(
-        new ObjectMapper()
+        OBJECT_MAPPER
             .createObjectNode()
             .put("actionId", actionPrompt.required("actionId").asText())
             .set("input", responseSsp.toJson()));
@@ -112,7 +113,7 @@ public class JitPublisher extends ConformanceParty {
 
     return request.createResponse(
         200,
-        Map.of("Api-Version", List.of(apiVersion)),
+        Map.of(API_VERSION, List.of(apiVersion)),
         new ConformanceMessageBody(jsonResponseBody));
   }
 }

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/SuppliedScenarioParameters.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/SuppliedScenarioParameters.java
@@ -1,7 +1,8 @@
 package org.dcsa.conformance.standards.jit.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Arrays;
 import java.util.Collections;
@@ -20,7 +21,7 @@ public class SuppliedScenarioParameters {
   }
 
   public ObjectNode toJson() {
-    ObjectNode objectNode = new ObjectMapper().createObjectNode();
+    ObjectNode objectNode = OBJECT_MAPPER.createObjectNode();
     map.forEach(
         (jitFilterParameter, value) ->
             objectNode.put(jitFilterParameter.getQueryParamName(), value));

--- a/lambda/src/main/java/org/dcsa/conformance/lambda/ApiLambda.java
+++ b/lambda/src/main/java/org/dcsa/conformance/lambda/ApiLambda.java
@@ -1,16 +1,16 @@
 package org.dcsa.conformance.lambda;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.dcsa.conformance.sandbox.ConformanceSandbox;
 import org.dcsa.conformance.sandbox.ConformanceWebRequest;
@@ -25,7 +25,7 @@ public class ApiLambda
       final APIGatewayProxyRequestEvent event, final Context context) {
     try {
       System.out.println("event = " + event + ", context = " + context);
-      JsonNode jsonEvent = new ObjectMapper().valueToTree(event);
+      JsonNode jsonEvent = OBJECT_MAPPER.valueToTree(event);
       log.info("jsonEvent = " + jsonEvent.toPrettyString());
 
       ConformancePersistenceProvider persistenceProvider =

--- a/lambda/src/main/java/org/dcsa/conformance/lambda/SandboxTaskLambda.java
+++ b/lambda/src/main/java/org/dcsa/conformance/lambda/SandboxTaskLambda.java
@@ -1,9 +1,10 @@
 package org.dcsa.conformance.lambda;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -34,7 +35,7 @@ public class SandboxTaskLambda implements RequestStreamHandler {
           LambdaToolkit.createDeferredSandboxTaskConsumer(persistenceProvider),
           jsonInput);
 
-      ObjectNode jsonOutput = new ObjectMapper().createObjectNode();
+      ObjectNode jsonOutput = OBJECT_MAPPER.createObjectNode();
       log.info("jsonOutput = " + jsonOutput.toPrettyString());
       try (BufferedWriter writer =
           new BufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8))) {

--- a/lambda/src/main/java/org/dcsa/conformance/lambda/WebuiLambda.java
+++ b/lambda/src/main/java/org/dcsa/conformance/lambda/WebuiLambda.java
@@ -1,13 +1,13 @@
 package org.dcsa.conformance.lambda;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import java.util.*;
-
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 import org.dcsa.conformance.core.toolkit.JsonToolkit;
 import org.dcsa.conformance.sandbox.ConformanceAccessException;
@@ -24,7 +24,7 @@ public class WebuiLambda
       System.out.println("event = " + event + ", context = " + context);
       log.info("event.getPath() = " + event.getPath());
 
-      JsonNode jsonEvent = new ObjectMapper().valueToTree(event);
+      JsonNode jsonEvent = OBJECT_MAPPER.valueToTree(event);
       log.info("JSON event = " + jsonEvent.toString());
 
       String cognitoIdAsEnvironmentId =

--- a/ovs/src/main/java/org/dcsa/conformance/standards/ovs/party/OvsPublisher.java
+++ b/ovs/src/main/java/org/dcsa/conformance/standards/ovs/party/OvsPublisher.java
@@ -1,16 +1,15 @@
 package org.dcsa.conformance.standards.ovs.party;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-
 import lombok.extern.slf4j.Slf4j;
 import org.dcsa.conformance.core.party.ConformanceParty;
 import org.dcsa.conformance.core.party.CounterpartConfiguration;
@@ -90,7 +89,7 @@ public class OvsPublisher extends ConformanceParty {
                             })));
 
     asyncOrchestratorPostPartyInput(
-        new ObjectMapper()
+        OBJECT_MAPPER
             .createObjectNode()
             .put("actionId", actionPrompt.required("actionId").asText())
             .set("input", responseSsp.toJson()));
@@ -112,7 +111,7 @@ public class OvsPublisher extends ConformanceParty {
 
     return request.createResponse(
         200,
-        Map.of("Api-Version", List.of(apiVersion)),
+        Map.of(API_VERSION, List.of(apiVersion)),
         new ConformanceMessageBody(jsonResponseBody));
   }
 }

--- a/ovs/src/main/java/org/dcsa/conformance/standards/ovs/party/SuppliedScenarioParameters.java
+++ b/ovs/src/main/java/org/dcsa/conformance/standards/ovs/party/SuppliedScenarioParameters.java
@@ -1,7 +1,8 @@
 package org.dcsa.conformance.standards.ovs.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Arrays;
 import java.util.Collections;
@@ -20,7 +21,7 @@ public class SuppliedScenarioParameters {
   }
 
   public ObjectNode toJson() {
-    ObjectNode objectNode = new ObjectMapper().createObjectNode();
+    ObjectNode objectNode = OBJECT_MAPPER.createObjectNode();
     map.forEach(
         (ovsFilterParameter, value) ->
             objectNode.put(ovsFilterParameter.getQueryParamName(), value));

--- a/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/party/PintReceivingPlatform.java
+++ b/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/party/PintReceivingPlatform.java
@@ -150,7 +150,7 @@ public class PintReceivingPlatform extends ConformanceParty {
       receiveState.save(persistentMap);
       return request.createResponse(
         responseCode.getHttpResponseCode(),
-        Map.of("API-Version", List.of(apiVersion)),
+        Map.of(API_VERSION, List.of(apiVersion)),
         new ConformanceMessageBody(signedPayloadJsonNode)
       );
     }
@@ -168,7 +168,7 @@ public class PintReceivingPlatform extends ConformanceParty {
     receiveState.save(persistentMap);
     return request.createResponse(
       201,
-      Map.of("API-Version", List.of(apiVersion)),
+      Map.of(API_VERSION, List.of(apiVersion)),
       new ConformanceMessageBody(unsignedPayload)
     );
   }
@@ -177,7 +177,7 @@ public class PintReceivingPlatform extends ConformanceParty {
   protected void exportPartyJsonState(ObjectNode targetObjectNode) {
     targetObjectNode.set(
       "envelopeReferences",
-      StateManagementUtil.storeMap(OBJECT_MAPPER, envelopeReferences));
+      StateManagementUtil.storeMap(envelopeReferences));
   }
 
   @Override
@@ -218,19 +218,19 @@ public class PintReceivingPlatform extends ConformanceParty {
           var payload = receiveState.generateSignedResponse(INCD, payloadSigner);
           return request.createResponse(
             INCD.getHttpResponseCode(),
-            Map.of("API-Version", List.of(apiVersion)),
+            Map.of(API_VERSION, List.of(apiVersion)),
             new ConformanceMessageBody(payload)
           );
         }
         receiveState.save(persistentMap);
         return request.createResponse(
           204,
-          Map.of("Api-Version", List.of(apiVersion)),
+          Map.of(API_VERSION, List.of(apiVersion)),
           new ConformanceMessageBody("")
         );
       }
       return request.createResponse(404,
-        Map.of("Api-Version", List.of(apiVersion)),
+        Map.of(API_VERSION, List.of(apiVersion)),
         new ConformanceMessageBody(
           OBJECT_MAPPER
             .createObjectNode()
@@ -253,13 +253,13 @@ public class PintReceivingPlatform extends ConformanceParty {
       receiveState.save(persistentMap);
       return request.createResponse(
         responseCode.getHttpResponseCode(),
-        Map.of("API-Version", List.of(apiVersion)),
+        Map.of(API_VERSION, List.of(apiVersion)),
         new ConformanceMessageBody(signedPayloadJsonNode)
       );
     }
 
     return request.createResponse(404,
-      Map.of("Api-Version", List.of(apiVersion)),
+      Map.of(API_VERSION, List.of(apiVersion)),
       new ConformanceMessageBody(
         OBJECT_MAPPER
           .createObjectNode()
@@ -281,7 +281,7 @@ public class PintReceivingPlatform extends ConformanceParty {
     } else {
       response = request.createResponse(
         404,
-        Map.of("Api-Version", List.of(apiVersion)),
+        Map.of(API_VERSION, List.of(apiVersion)),
         new ConformanceMessageBody(
           OBJECT_MAPPER
             .createObjectNode()

--- a/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/party/PintSendingPlatform.java
+++ b/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/party/PintSendingPlatform.java
@@ -422,7 +422,7 @@ public class PintSendingPlatform extends ConformanceParty {
     log.info("EblInteropSendingPlatform.handleRequest(%s)".formatted(request));
     return request.createResponse(
       404,
-      Map.of("Api-Version", List.of(apiVersion)),
+      Map.of(API_VERSION, List.of(apiVersion)),
       new ConformanceMessageBody(
         OBJECT_MAPPER
           .createObjectNode()

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<log4j.version>2.20.0</log4j.version>
-		<junit.version>5.11.0</junit.version>
+		<junit.version>5.11.1</junit.version>
 		<lombok.version>1.18.34</lombok.version>
 
 		<junit.includedTags>!WebUI</junit.includedTags>

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -54,7 +54,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.24.0</version>
+			<version>4.25.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-boot/src/test/java/org/dcsa/conformance/manual/ManualTestBase.java
+++ b/spring-boot/src/test/java/org/dcsa/conformance/manual/ManualTestBase.java
@@ -1,5 +1,6 @@
 package org.dcsa.conformance.manual;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -25,7 +26,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 public abstract class ManualTestBase {
   private static final String USER_ID = "unit-test";
 
-  protected final ObjectMapper mapper = new ObjectMapper();
+  protected final ObjectMapper mapper = OBJECT_MAPPER;
   protected long lambdaDelay = 0L;
 
   @Autowired protected ConformanceApplication app;
@@ -326,7 +327,7 @@ public abstract class ManualTestBase {
       String sandboxName) {}
 
   // Possible result of getAllSandboxes
-  record SandboxItem(String id, String name, String operatorLog, boolean canNotifyParty) {}
+  protected record SandboxItem(String id, String name, String operatorLog, boolean canNotifyParty) {}
 
   public record SandboxConfig(
       String sandboxId,

--- a/tnt/src/main/java/org/dcsa/conformance/standards/tnt/party/SuppliedScenarioParameters.java
+++ b/tnt/src/main/java/org/dcsa/conformance/standards/tnt/party/SuppliedScenarioParameters.java
@@ -1,7 +1,8 @@
 package org.dcsa.conformance.standards.tnt.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Arrays;
 import java.util.Collections;
@@ -20,10 +21,10 @@ public class SuppliedScenarioParameters {
   }
 
   public ObjectNode toJson() {
-    ObjectNode objectNode = new ObjectMapper().createObjectNode();
+    ObjectNode objectNode = OBJECT_MAPPER.createObjectNode();
     map.forEach(
-      (ovsFilterParameter, value) ->
-        objectNode.put(ovsFilterParameter.getQueryParamName(), value));
+      (tntFilterParameter, value) ->
+        objectNode.put(tntFilterParameter.getQueryParamName(), value));
     return objectNode;
   }
 
@@ -34,11 +35,11 @@ public class SuppliedScenarioParameters {
   public static SuppliedScenarioParameters fromJson(JsonNode jsonNode) {
     return new SuppliedScenarioParameters(
       Arrays.stream(TntFilterParameter.values())
-        .filter(ovsFilterParameter -> jsonNode.has(ovsFilterParameter.getQueryParamName()))
+        .filter(tntFilterParameter -> jsonNode.has(tntFilterParameter.getQueryParamName()))
         .collect(
           Collectors.toUnmodifiableMap(
             Function.identity(),
-            ovsFilterParameter ->
-              jsonNode.required(ovsFilterParameter.getQueryParamName()).asText())));
+            tntFilterParameter ->
+              jsonNode.required(tntFilterParameter.getQueryParamName()).asText())));
   }
 }

--- a/tnt/src/main/java/org/dcsa/conformance/standards/tnt/party/TntPublisher.java
+++ b/tnt/src/main/java/org/dcsa/conformance/standards/tnt/party/TntPublisher.java
@@ -1,7 +1,8 @@
 package org.dcsa.conformance.standards.tnt.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -66,8 +67,8 @@ public class TntPublisher extends ConformanceParty {
                     actionPrompt.required("tntFilterParametersQueryParamNames").spliterator(),
                     false)
                 .map(
-                    jsonOvsFilterParameter ->
-                        TntFilterParameter.byQueryParamName.get(jsonOvsFilterParameter.asText()))
+                    jsonTntFilterParameter ->
+                        TntFilterParameter.byQueryParamName.get(jsonTntFilterParameter.asText()))
                 .collect(
                     Collectors.toMap(
                         Function.identity(),
@@ -102,7 +103,7 @@ public class TntPublisher extends ConformanceParty {
                             })));
 
     asyncOrchestratorPostPartyInput(
-        new ObjectMapper()
+        OBJECT_MAPPER
             .createObjectNode()
             .put("actionId", actionPrompt.required("actionId").asText())
             .set("input", responseSsp.toJson()));
@@ -122,7 +123,7 @@ public class TntPublisher extends ConformanceParty {
 
     return request.createResponse(
         200,
-        Map.of("Api-Version", List.of(apiVersion)),
+        Map.of(API_VERSION, List.of(apiVersion)),
         new ConformanceMessageBody(jsonResponseBody));
   }
 }


### PR DESCRIPTION
* use one objectMapper everywhere
* use "Api-Version" from one location
* fix some typos of copy-paste issues from the past
* give better error message, when schema file is not found
* update deps

Build fails on duplicated code, outside of the scope of this PR. So, ignoring that. All tests do work. 