### PR TITLE
Fix build instructions: start Spring Boot from command-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Adopters use an AWS deployment of the Conformance Framework managed by DCSA.
 ### Java
 1. Build the project using Maven:
     ```sh
-    mvn package -DskipTests
+    mvn clean package -DskipTests
     ```
 2. Run the application:
     ```sh
-    mvn spring-boot:run
+    mvn -pl spring-boot -am spring-boot:run
     ```
 
 ### Angular and NodeJS Web UI

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
 		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+		<spring.boot.version>3.3.4</spring.boot.version>
 		<log4j.version>2.20.0</log4j.version>
 		<junit.version>5.11.1</junit.version>
 		<lombok.version>1.18.34</lombok.version>
@@ -206,6 +207,14 @@
 						</configuration>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>${spring.boot.version}</version>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
 			</plugin>
 		</plugins>
 

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -15,7 +15,6 @@
 
 	<properties>
 		<spring-cloud.version>2023.0.3</spring-cloud.version>
-		<spring.boot.version>3.3.4</spring.boot.version>
 	</properties>
 
 	<dependencies>
@@ -78,6 +77,7 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<version>${spring.boot.version}</version>
 				<configuration>
+					<skip>false</skip>
 					<excludes>
 						<exclude>
 							<groupId>org.projectlombok</groupId>


### PR DESCRIPTION
Current description does not work. 

Note: Spring Boot is not added as a normal dependency, only a build plugin is added to the root project. 