### PR TITLE
DT-1678: Add missing actionId to EblCarrier and fail Conformance upon missing actionId

### DIFF
--- a/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceOrchestrator.java
+++ b/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceOrchestrator.java
@@ -246,8 +246,11 @@ public class ConformanceOrchestrator implements StatefulEntity {
       return;
     }
 
-    String actionId = partyInput.get("actionId").asText();
-    if (!Objects.equals(actionId, nextAction.getId().toString())) {
+    String actionId = partyInput.path("actionId").asText(null);
+    if (actionId == null) {
+      log.error("Missing required 'actionId' in given party input: {}", partyInput.toPrettyString());
+    }
+    if (actionId != null && !Objects.equals(actionId, nextAction.getId().toString())) {
       log.info(
           "Ignoring party input %s: the expected next action id is %s in current scenario %s"
               .formatted(


### PR DESCRIPTION
First commit achieves: Log an error on missing actionId.
Note: Conformance will automatically not be green, after this change.

Note to Niels: you can continue on it, from here. The build should fail. 