### PR TITLE
STNG-8 Reuse HttpClient

### DIFF
--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/party/BookingCarrier.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/party/BookingCarrier.java
@@ -1,5 +1,7 @@
 package org.dcsa.conformance.standards.booking.party;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.time.Instant;
@@ -21,8 +23,6 @@ import org.dcsa.conformance.core.traffic.ConformanceResponse;
 import org.dcsa.conformance.standards.booking.action.*;
 import org.dcsa.conformance.standards.booking.checks.ScenarioType;
 import org.dcsa.conformance.standards.booking.model.PersistableCarrierBooking;
-
-import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 @Slf4j
 public class BookingCarrier extends ConformanceParty {
@@ -91,7 +91,8 @@ public class BookingCarrier extends ConformanceParty {
   }
 
   private void supplyScenarioParameters(JsonNode actionPrompt) {
-    log.info("Carrier.supplyScenarioParameters(%s)".formatted(actionPrompt.toPrettyString()));
+    if (log.isInfoEnabled())
+      log.info("Carrier.supplyScenarioParameters({})", actionPrompt.toPrettyString());
     var scenarioType = ScenarioType.valueOf(actionPrompt.required("scenarioType").asText());
     CarrierScenarioParameters carrierScenarioParameters = switch (scenarioType) {
     case REGULAR, REGULAR_SHIPPER_OWNED -> new CarrierScenarioParameters("SCR-1234-REGULAR",

--- a/core/src/main/java/org/dcsa/conformance/core/party/ConformanceParty.java
+++ b/core/src/main/java/org/dcsa/conformance/core/party/ConformanceParty.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
@@ -22,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.dcsa.conformance.core.scenario.ConformanceAction;
 import org.dcsa.conformance.core.state.JsonNodeMap;
 import org.dcsa.conformance.core.state.StatefulEntity;
+import org.dcsa.conformance.core.toolkit.IOToolkit;
 import org.dcsa.conformance.core.toolkit.JsonToolkit;
 import org.dcsa.conformance.core.traffic.ConformanceMessage;
 import org.dcsa.conformance.core.traffic.ConformanceMessageBody;
@@ -297,11 +297,11 @@ public abstract class ConformanceParty implements StatefulEntity {
                 + "/party/%s/prompt/json".formatted(partyConfiguration.getName()));
     log.info("ConformanceParty.getPartyPrompt() calling: %s".formatted(uri));
     HttpRequest.Builder httpRequestBuilder =
-        HttpRequest.newBuilder().uri(uri).timeout(Duration.ofHours(1)).GET();
+        HttpRequest.newBuilder().uri(uri).timeout(Duration.ofMinutes(1)).GET();
     orchestratorAuthHeader.forEach(
         (name, values) -> values.forEach(value -> httpRequestBuilder.header(name, value)));
     String stringResponseBody =
-        HttpClient.newHttpClient()
+      IOToolkit.HTTP_CLIENT
             .send(httpRequestBuilder.build(), HttpResponse.BodyHandlers.ofString())
             .body();
     return new ConformanceMessageBody(stringResponseBody).getJsonBody();

--- a/core/src/main/java/org/dcsa/conformance/core/party/ConformanceParty.java
+++ b/core/src/main/java/org/dcsa/conformance/core/party/ConformanceParty.java
@@ -296,8 +296,9 @@ public abstract class ConformanceParty implements StatefulEntity {
             partyConfiguration.getOrchestratorUrl()
                 + "/party/%s/prompt/json".formatted(partyConfiguration.getName()));
     log.info("ConformanceParty.getPartyPrompt() calling: %s".formatted(uri));
+    // Allow long debugging sessions or slow business logic at customer's side
     HttpRequest.Builder httpRequestBuilder =
-        HttpRequest.newBuilder().uri(uri).timeout(Duration.ofMinutes(1)).GET();
+        HttpRequest.newBuilder().uri(uri).timeout(Duration.ofHours(1)).GET();
     orchestratorAuthHeader.forEach(
         (name, values) -> values.forEach(value -> httpRequestBuilder.header(name, value)));
     String stringResponseBody =

--- a/core/src/main/java/org/dcsa/conformance/core/toolkit/IOToolkit.java
+++ b/core/src/main/java/org/dcsa/conformance/core/toolkit/IOToolkit.java
@@ -1,7 +1,6 @@
 package org.dcsa.conformance.core.toolkit;
 
 import java.net.http.HttpClient;
-import java.time.Duration;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
@@ -10,6 +9,5 @@ public class IOToolkit {
   public static final HttpClient HTTP_CLIENT =
       HttpClient.newBuilder()
           .followRedirects(HttpClient.Redirect.NORMAL)
-          .connectTimeout(Duration.ofSeconds(30))
           .build();
 }

--- a/core/src/main/java/org/dcsa/conformance/core/toolkit/IOToolkit.java
+++ b/core/src/main/java/org/dcsa/conformance/core/toolkit/IOToolkit.java
@@ -1,0 +1,15 @@
+package org.dcsa.conformance.core.toolkit;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class IOToolkit {
+
+  public static final HttpClient HTTP_CLIENT =
+      HttpClient.newBuilder()
+          .followRedirects(HttpClient.Redirect.NORMAL)
+          .connectTimeout(Duration.ofSeconds(30))
+          .build();
+}

--- a/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceSandbox.java
+++ b/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceSandbox.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
@@ -23,6 +22,7 @@ import org.dcsa.conformance.core.party.ConformanceParty;
 import org.dcsa.conformance.core.party.CounterpartConfiguration;
 import org.dcsa.conformance.core.party.PartyWebClient;
 import org.dcsa.conformance.core.state.JsonNodeMap;
+import org.dcsa.conformance.core.toolkit.IOToolkit;
 import org.dcsa.conformance.core.toolkit.JsonToolkit;
 import org.dcsa.conformance.core.traffic.*;
 import org.dcsa.conformance.sandbox.configuration.SandboxConfiguration;
@@ -662,12 +662,9 @@ public class ConformanceSandbox {
         .headers()
         .forEach((name, values) -> values.forEach(value -> httpRequestBuilder.header(name, value)));
 
-    HttpResponse<String> httpResponse;
-    try (HttpClient httpClient =
-        HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build()) {
-      httpResponse =
-          httpClient.send(httpRequestBuilder.build(), HttpResponse.BodyHandlers.ofString());
-    }
+    HttpResponse<String> httpResponse =
+        IOToolkit.HTTP_CLIENT.send(
+            httpRequestBuilder.build(), HttpResponse.BodyHandlers.ofString());
     ConformanceResponse conformanceResponse =
         conformanceRequest.createResponse(
             httpResponse.statusCode(),
@@ -722,9 +719,7 @@ public class ConformanceSandbox {
           .headers()
           .forEach(
               (name, values) -> values.forEach(value -> httpRequestBuilder.header(name, value)));
-      try (HttpClient httpClient = HttpClient.newHttpClient()) {
-        httpClient.send(httpRequestBuilder.build(), HttpResponse.BodyHandlers.ofString());
-      }
+      IOToolkit.HTTP_CLIENT.send(httpRequestBuilder.build(), HttpResponse.BodyHandlers.ofString());
     } catch (Exception e) {
       log.error(
           "Failed to send outbound request: %s"

--- a/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceSandbox.java
+++ b/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceSandbox.java
@@ -239,14 +239,13 @@ public class ConformanceSandbox {
       ConformanceWebRequest webRequest,
       Consumer<JsonNode> deferredSandboxTaskConsumer) {
     log.info(
-        "ConformanceSandbox.handleRequest() "
-            + OBJECT_MAPPER.valueToTree(webRequest).toPrettyString());
+        "ConformanceSandbox.handleRequest() {}",
+        OBJECT_MAPPER.valueToTree(webRequest).toPrettyString());
 
     String expectedPrefix = "/conformance/sandbox/";
     int expectedPrefixStart = webRequest.url().indexOf(expectedPrefix);
     if (expectedPrefixStart < 0) {
-      log.info(
-          "Rejecting request with missing '%s' in: %s".formatted(expectedPrefix, webRequest.url()));
+      log.info("Rejecting request with missing '{}' in: {}", expectedPrefix, webRequest.url());
       return new ConformanceWebResponse(404, JsonToolkit.JSON_UTF_8, Collections.emptyMap(), "{}");
     }
     String remainingUri = webRequest.url().substring(expectedPrefixStart + expectedPrefix.length());
@@ -594,7 +593,7 @@ public class ConformanceSandbox {
             .put("handler", "_syncHandleOutboundRequest")
             .put("sandboxId", sandboxId)
             .set("conformanceRequest", conformanceRequest.toJson());
-    log.debug("Deferring task: " + deferredTask.toPrettyString());
+    log.debug("Deferring task: {}", deferredTask.toPrettyString());
     deferredSandboxTaskConsumer.accept(deferredTask);
   }
 
@@ -605,7 +604,7 @@ public class ConformanceSandbox {
             .createObjectNode()
             .put("handler", "_syncSendOutboundWebRequest")
             .set("conformanceWebRequest", conformanceWebRequest.toJson());
-    log.debug("Deferring task: " + deferredTask.toPrettyString());
+    log.debug("Deferring task: {}", deferredTask.toPrettyString());
     deferredSandboxTaskConsumer.accept(deferredTask);
   }
 
@@ -614,7 +613,7 @@ public class ConformanceSandbox {
       Consumer<JsonNode> deferredSandboxTaskConsumer,
       JsonNode jsonNode) {
     try {
-      log.debug("ConformanceSandbox.executeDeferredTask(%s)".formatted(jsonNode.toPrettyString()));
+      log.debug("ConformanceSandbox.executeDeferredTask({})", jsonNode.toPrettyString());
       switch (jsonNode.path("handler").asText()) {
         case "_syncHandleOutboundRequest":
           _syncHandleOutboundRequest(
@@ -628,7 +627,7 @@ public class ConformanceSandbox {
               ConformanceWebRequest.fromJson((ObjectNode) jsonNode.get("conformanceWebRequest")));
           return;
         default:
-          log.error("Unsupported deferred task: " + jsonNode.toPrettyString());
+          log.error("Unsupported deferred task: {}", jsonNode.toPrettyString());
       }
     } catch (Exception e) {
       log.error(
@@ -642,8 +641,9 @@ public class ConformanceSandbox {
   private static ConformanceResponse _syncHttpRequest(ConformanceRequest conformanceRequest) {
     URI uri = conformanceRequest.toURI();
     log.info(
-        "ConformanceSandbox.syncHttpRequest(%s) request: %s"
-            .formatted(uri, conformanceRequest.toJson().toPrettyString()));
+        "ConformanceSandbox.syncHttpRequest({}) request: {}",
+        uri,
+        conformanceRequest.toJson().toPrettyString());
 
     HttpRequest.Builder httpRequestBuilder =
         "GET".equals(conformanceRequest.method())
@@ -655,7 +655,7 @@ public class ConformanceSandbox {
                     HttpRequest.BodyPublishers.ofString(
                         conformanceRequest.message().body().getStringBody()));
 
-    httpRequestBuilder.timeout(Duration.ofHours(1));
+    httpRequestBuilder.timeout(Duration.ofMinutes(1));
 
     conformanceRequest
         .message()
@@ -671,8 +671,8 @@ public class ConformanceSandbox {
             httpResponse.headers().map(),
             new ConformanceMessageBody(httpResponse.body()));
     log.info(
-        "ConformanceSandbox.syncHttpRequest() response: %s"
-            .formatted(conformanceResponse.toJson().toPrettyString()));
+        "ConformanceSandbox.syncHttpRequest() response: {}",
+        conformanceResponse.toJson().toPrettyString());
     return conformanceResponse;
   }
 
@@ -713,7 +713,7 @@ public class ConformanceSandbox {
       HttpRequest.Builder httpRequestBuilder =
           HttpRequest.newBuilder()
               .uri(URI.create(conformanceWebRequest.url()))
-              .timeout(Duration.ofHours(1))
+              .timeout(Duration.ofMinutes(1))
               .GET();
       conformanceWebRequest
           .headers()
@@ -722,8 +722,8 @@ public class ConformanceSandbox {
       IOToolkit.HTTP_CLIENT.send(httpRequestBuilder.build(), HttpResponse.BodyHandlers.ofString());
     } catch (Exception e) {
       log.error(
-          "Failed to send outbound request: %s"
-              .formatted(conformanceWebRequest.toJson().toPrettyString()),
+          "Failed to send outbound request: {}",
+          conformanceWebRequest.toJson().toPrettyString(),
           e);
     }
   }
@@ -744,8 +744,9 @@ public class ConformanceSandbox {
             orchestrator -> partyPromptReference.set(orchestrator.handleGetPartyPrompt(partyName)))
         .run();
     log.info(
-        "Returning prompt for party %s: %s"
-            .formatted(partyName, partyPromptReference.get().toPrettyString()));
+        "Returning prompt for party {}: {}",
+        partyName,
+        partyPromptReference.get().toPrettyString());
     return new ConformanceWebResponse(
         200,
         JsonToolkit.JSON_UTF_8,

--- a/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceSandbox.java
+++ b/sandbox/src/main/java/org/dcsa/conformance/sandbox/ConformanceSandbox.java
@@ -655,7 +655,8 @@ public class ConformanceSandbox {
                     HttpRequest.BodyPublishers.ofString(
                         conformanceRequest.message().body().getStringBody()));
 
-    httpRequestBuilder.timeout(Duration.ofMinutes(1));
+    // Allow long debugging sessions or slow business logic at customer's side
+    httpRequestBuilder.timeout(Duration.ofHours(1));
 
     conformanceRequest
         .message()
@@ -710,10 +711,11 @@ public class ConformanceSandbox {
 
   private static void _syncSendOutboundWebRequest(ConformanceWebRequest conformanceWebRequest) {
     try {
+      // Allow long debugging sessions or slow business logic at customer's side
       HttpRequest.Builder httpRequestBuilder =
           HttpRequest.newBuilder()
               .uri(URI.create(conformanceWebRequest.url()))
-              .timeout(Duration.ofMinutes(1))
+              .timeout(Duration.ofHours(1))
               .GET();
       conformanceWebRequest
           .headers()


### PR DESCRIPTION
Reuse it, to avoid creating many threads and expensive objects.

Separated 2 different commits:
1. HttpClient improvements
2. Logging changes.