### PR TITLE
STNG-25 Replace OpenCSV by plain Java

### DIFF
--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/checks/BookingDataSets.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/checks/BookingDataSets.java
@@ -11,9 +11,9 @@ public class BookingDataSets {
 
   public static final KeywordDataset CUTOFF_DATE_TIME_CODES = KeywordDataset.staticDataset("DCO", "VCO", "FCO", "LCO", "ECP", "EFC");
 
-  public static final KeywordDataset REFERENCE_TYPES = KeywordDataset.fromCSV(BookingDataSets.class, "/standards/booking/datasets/general-reference-types.csv", "General Reference Type Code");
+  public static final KeywordDataset REFERENCE_TYPES = KeywordDataset.fromCSV("/standards/booking/datasets/general-reference-types.csv", "General Reference Type Code");
 
-  public static final KeywordDataset DG_SEGREGATION_GROUPS = KeywordDataset.fromCSV(BookingDataSets.class, "/standards/booking/datasets/segregationgroups.csv");
+  public static final KeywordDataset DG_SEGREGATION_GROUPS = KeywordDataset.fromCSV("/standards/booking/datasets/segregationgroups.csv");
 
   public static final KeywordDataset INHALATION_ZONE_CODE = KeywordDataset.staticDataset("A", "B", "C", "D");
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,9 +24,9 @@
 			<version>1.1.0</version>
 		</dependency>
 		<dependency>
-			<groupId>com.opencsv</groupId>
-			<artifactId>opencsv</artifactId>
-			<version>5.9</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+			<version>1.12.0</version>
 		</dependency>
 
 		<dependency>

--- a/core/src/main/java/org/dcsa/conformance/core/check/KeywordDataset.java
+++ b/core/src/main/java/org/dcsa/conformance/core/check/KeywordDataset.java
@@ -2,7 +2,6 @@ package org.dcsa.conformance.core.check;
 
 import static org.dcsa.conformance.core.check.KeywordDatasets.*;
 
-import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Supplier;
 import lombok.NonNull;
@@ -48,18 +47,18 @@ public interface KeywordDataset {
   }
 
   static KeywordDataset fromCSV(String resourceName) {
-    Path resource = getAndCheckResource(resourceName);
-    return KeywordDataset.lazyLoaded(() -> loadCsvDataset(resource, SELECT_FIRST_COLUMN));
+    checkResource(resourceName);
+    return KeywordDataset.lazyLoaded(() -> loadCsvDataset(resourceName, SELECT_FIRST_COLUMN));
   }
 
   static KeywordDataset fromCSV(String resourceName, String columnName) {
-    Path resource = getAndCheckResource(resourceName);
-    return KeywordDataset.lazyLoaded(() -> loadCsvDataset(resource, SelectColumn.withName(columnName)));
+    checkResource(resourceName);
+    return KeywordDataset.lazyLoaded(() -> loadCsvDataset(resourceName, SelectColumn.withName(columnName)));
   }
 
   static KeywordDataset fromCSVCombiningColumns(String resourceName, String delimiter, String ... columnNames) {
-    Path resource = getAndCheckResource(resourceName);
-    return KeywordDataset.lazyLoaded(() -> loadCsvDataset(resource, new CombineColumnSelector(delimiter, columnNames)));
+    checkResource(resourceName);
+    return KeywordDataset.lazyLoaded(() -> loadCsvDataset(resourceName, new CombineColumnSelector(delimiter, columnNames)));
   }
 
   static KeywordDataset fromVersionedCSV(String nameTemplate) {

--- a/core/src/main/java/org/dcsa/conformance/core/check/KeywordDataset.java
+++ b/core/src/main/java/org/dcsa/conformance/core/check/KeywordDataset.java
@@ -2,6 +2,7 @@ package org.dcsa.conformance.core.check;
 
 import static org.dcsa.conformance.core.check.KeywordDatasets.*;
 
+import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Supplier;
 import lombok.NonNull;
@@ -46,30 +47,30 @@ public interface KeywordDataset {
     );
   }
 
-  static KeywordDataset fromCSV(Class<?> resourceClass, String resourceName) {
-    checkResource(resourceClass, resourceName);
-    return KeywordDataset.lazyLoaded(() -> loadCsvDataset(resourceClass, resourceName, SELECT_FIRST_COLUMN));
+  static KeywordDataset fromCSV(String resourceName) {
+    Path resource = getAndCheckResource(resourceName);
+    return KeywordDataset.lazyLoaded(() -> loadCsvDataset(resource, SELECT_FIRST_COLUMN));
   }
 
-  static KeywordDataset fromCSV(Class<?> resourceClass, String resourceName, String columnName) {
-    checkResource(resourceClass, resourceName);
-    return KeywordDataset.lazyLoaded(() -> loadCsvDataset(resourceClass, resourceName, SelectColumn.withName(columnName)));
+  static KeywordDataset fromCSV(String resourceName, String columnName) {
+    Path resource = getAndCheckResource(resourceName);
+    return KeywordDataset.lazyLoaded(() -> loadCsvDataset(resource, SelectColumn.withName(columnName)));
   }
 
-  static KeywordDataset fromCSVCombiningColumns(Class<?> resourceClass, String resourceName, String delimiter, String ... columnNames) {
-    checkResource(resourceClass, resourceName);
-    return KeywordDataset.lazyLoaded(() -> loadCsvDataset(resourceClass, resourceName, new CombineColumnSelector(delimiter, columnNames)));
+  static KeywordDataset fromCSVCombiningColumns(String resourceName, String delimiter, String ... columnNames) {
+    Path resource = getAndCheckResource(resourceName);
+    return KeywordDataset.lazyLoaded(() -> loadCsvDataset(resource, new CombineColumnSelector(delimiter, columnNames)));
   }
 
-  static KeywordDataset fromVersionedCSV(Class<?> resourceClass, String nameTemplate) {
-    return VersionedKeywordDataset.of(resourceClass, nameTemplate, SELECT_FIRST_COLUMN);
+  static KeywordDataset fromVersionedCSV(String nameTemplate) {
+    return VersionedKeywordDataset.of(nameTemplate, SELECT_FIRST_COLUMN);
   }
 
-  static KeywordDataset fromVersionedCSV(Class<?> resourceClass, String nameTemplate, String columnName) {
-    return VersionedKeywordDataset.of(resourceClass, nameTemplate, SelectColumn.withName(columnName));
+  static KeywordDataset fromVersionedCSV(String nameTemplate, String columnName) {
+    return VersionedKeywordDataset.of(nameTemplate, SelectColumn.withName(columnName));
   }
 
-  static KeywordDataset fromVersionedCSV(Class<?> resourceClass, String nameTemplate, String delimiter, String ... columnNames) {
-    return VersionedKeywordDataset.of(resourceClass, nameTemplate, new CombineColumnSelector(delimiter, columnNames));
+  static KeywordDataset fromVersionedCSV(String nameTemplate, String delimiter, String ... columnNames) {
+    return VersionedKeywordDataset.of(nameTemplate, new CombineColumnSelector(delimiter, columnNames));
   }
 }

--- a/core/src/main/java/org/dcsa/conformance/core/check/KeywordDatasets.java
+++ b/core/src/main/java/org/dcsa/conformance/core/check/KeywordDatasets.java
@@ -41,6 +41,7 @@ class KeywordDatasets {
 
     Set<String> keywords = HashSet.newHashSet(lines.size());
     lines.stream()
+        .skip(1) // Skip header line
         .map(line -> line.split(","))
         .map(row -> selector.selectValue(fileName, row))
         .forEach(keywords::add);

--- a/core/src/main/java/org/dcsa/conformance/core/check/KeywordDatasets.java
+++ b/core/src/main/java/org/dcsa/conformance/core/check/KeywordDatasets.java
@@ -1,5 +1,6 @@
 package org.dcsa.conformance.core.check;
 
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -15,7 +16,9 @@ class KeywordDatasets {
 
   static Path getAndCheckResource(@NonNull String resourceName) {
     try {
-      Path resourcePath = Paths.get(KeywordDatasets.class.getResource(resourceName).toURI());
+      URI uri = KeywordDatasets.class.getResource(resourceName).toURI();
+      System.out.println("URI = " + uri);
+      Path resourcePath = Paths.get(uri);
       if (!Files.exists(resourcePath)) {
         throw new IllegalArgumentException("Could not find the resource: " + resourceName);
       }

--- a/core/src/main/java/org/dcsa/conformance/core/check/VersionedKeywordDataset.java
+++ b/core/src/main/java/org/dcsa/conformance/core/check/VersionedKeywordDataset.java
@@ -1,6 +1,5 @@
 package org.dcsa.conformance.core.check;
 
-import java.nio.file.Path;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -49,8 +48,8 @@ class VersionedKeywordDataset implements KeywordDataset {
     }
     return fromLoader(version -> {
       var resourceName = nameTemplate.formatted(version);
-      Path resource = KeywordDatasets.getAndCheckResource(resourceName);
-      return KeywordDatasets.loadCsvDataset(resource, rowSelector);
+      KeywordDatasets.checkResource(resourceName);
+      return KeywordDatasets.loadCsvDataset(resourceName, rowSelector);
     });
   }
 }

--- a/core/src/main/java/org/dcsa/conformance/core/check/VersionedKeywordDataset.java
+++ b/core/src/main/java/org/dcsa/conformance/core/check/VersionedKeywordDataset.java
@@ -1,7 +1,6 @@
 package org.dcsa.conformance.core.check;
 
-import static org.dcsa.conformance.core.check.KeywordDatasets.loadCsvDataset;
-
+import java.nio.file.Path;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -44,13 +43,14 @@ class VersionedKeywordDataset implements KeywordDataset {
     return new VersionedKeywordDataset(datasetLoader);
   }
 
-  static KeywordDataset of(Class<?> resourceClass, String nameTemplate, KeywordDatasets.CSVRowSelector rowSelector) {
+  static KeywordDataset of(String nameTemplate, KeywordDatasets.CSVRowSelector rowSelector) {
     if (!nameTemplate.contains("%s")) {
       throw new IllegalStateException("Missing a '%s' to mark where the version will be placed");
     }
     return fromLoader(version -> {
       var resourceName = nameTemplate.formatted(version);
-      return loadCsvDataset(resourceClass, resourceName, rowSelector);
+      Path resource = KeywordDatasets.getAndCheckResource(resourceName);
+      return KeywordDatasets.loadCsvDataset(resource, rowSelector);
     });
   }
 }

--- a/core/src/test/java/org/dcsa/conformance/core/check/KeywordDatasetTest.java
+++ b/core/src/test/java/org/dcsa/conformance/core/check/KeywordDatasetTest.java
@@ -1,6 +1,7 @@
 package org.dcsa.conformance.core.check;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -8,12 +9,19 @@ import org.junit.jupiter.api.Test;
 class KeywordDatasetTest {
 
   @Test
-  void convertCSVFileTo() {
+  void convertCorrectCSVFileToKeywordDataset() {
     KeywordDataset code =
         KeywordDataset.fromCSV("/convert-csv-file.csv", "General Reference Type Code");
     assertTrue(code.contains("SAC"));
     assertTrue(code.contains("BID"));
     assertTrue(code.contains("FF"));
     assertFalse(code.contains("General Reference Type Code")); // Header should be skipped
+  }
+
+  @Test
+  void convertWrongCSVFile() {
+    KeywordDataset code =
+        KeywordDataset.fromCSV("/convert-csv-file_wrong.csv", "General Reference Type Code");
+    assertThrows(IllegalArgumentException.class, () -> code.contains("SAC"));
   }
 }

--- a/core/src/test/java/org/dcsa/conformance/core/check/KeywordDatasetTest.java
+++ b/core/src/test/java/org/dcsa/conformance/core/check/KeywordDatasetTest.java
@@ -1,5 +1,6 @@
 package org.dcsa.conformance.core.check;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -12,5 +13,7 @@ class KeywordDatasetTest {
         KeywordDataset.fromCSV("/convert-csv-file.csv", "General Reference Type Code");
     assertTrue(code.contains("SAC"));
     assertTrue(code.contains("BID"));
+    assertTrue(code.contains("FF"));
+    assertFalse(code.contains("General Reference Type Code")); // Header should be skipped
   }
 }

--- a/core/src/test/java/org/dcsa/conformance/core/check/KeywordDatasetTest.java
+++ b/core/src/test/java/org/dcsa/conformance/core/check/KeywordDatasetTest.java
@@ -1,0 +1,16 @@
+package org.dcsa.conformance.core.check;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class KeywordDatasetTest {
+
+  @Test
+  void convertCSVFileTo() {
+    KeywordDataset code =
+        KeywordDataset.fromCSV("/convert-csv-file.csv", "General Reference Type Code");
+    assertTrue(code.contains("SAC"));
+    assertTrue(code.contains("BID"));
+  }
+}

--- a/core/src/test/resources/convert-csv-file.csv
+++ b/core/src/test/resources/convert-csv-file.csv
@@ -1,0 +1,12 @@
+General Reference Type Code,General Reference Type Name,General Reference Type Description
+FF,Freight Forwarder’s Reference,Reference assigned to the shipment by the freight forwarder.
+SI,Shipper’s Reference,Reference assigned to the shipment by the shipper.
+SPO,Shippers Purchace Order Reference,The PO reference assigned to the shipment by the Shipper
+CPO,Consignees Purchase Order Reference,The PO reference that the shipper or freight forwarder received from the consignee and then shared with the carrier.
+CR,Customer’s Reference,Reference assigned to the shipment by the customer.
+AAO,Consignee’s Reference,Reference assigned to the shipment by the consignee.
+ECR,Empty container release reference,Unique identifier to enable release of the container from a carrier nominated depot
+CSI,Customer shipment ID,Unique Shipment ID for the booking in the Shipper or Forwarder system. Used to identify the booking along with the Booking party.
+BPR,Booking party reference number,A unique identifier provided by a booking party in the booking request.
+BID,Booking Request ID,The associated booking request ID provided by the shipper.
+SAC,Shipping Agency Code,

--- a/core/src/test/resources/convert-csv-file_wrong.csv
+++ b/core/src/test/resources/convert-csv-file_wrong.csv
@@ -1,0 +1,2 @@
+General Reference Type Code,General Reference Type Name,General Reference Type Description
+FF,Freight Forwarder’s Reference,Reference assigned, to the shipment by the freight forwarder.

--- a/ebl/pom.xml
+++ b/ebl/pom.xml
@@ -33,10 +33,5 @@
 			<artifactId>canonical-json</artifactId>
 			<version>2.3</version>
 		</dependency>
-		<dependency>
-			<groupId>com.opencsv</groupId>
-			<artifactId>opencsv</artifactId>
-			<version>5.9</version>
-		</dependency>
 	</dependencies>
 </project>

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EblDatasets.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EblDatasets.java
@@ -28,8 +28,8 @@ public class EblDatasets {
   );
 
 
-  public static final KeywordDataset DG_INHALATION_ZONES = KeywordDataset.fromCSV(EblDatasets.class, "/standards/ebl/datasets/inhalationzones.csv");
-  public static final KeywordDataset DG_SEGREGATION_GROUPS = KeywordDataset.fromCSV(EblDatasets.class, "/standards/ebl/datasets/segregationgroups.csv");
+  public static final KeywordDataset DG_INHALATION_ZONES = KeywordDataset.fromCSV("/standards/ebl/datasets/inhalationzones.csv");
+  public static final KeywordDataset DG_SEGREGATION_GROUPS = KeywordDataset.fromCSV("/standards/ebl/datasets/segregationgroups.csv");
 
   public static final KeywordDataset WOOD_DECLARATION_VALUES = KeywordDataset.staticDataset(
     "Not Applicable",

--- a/spring-boot/src/test/java/org/dcsa/conformance/manual/ManualScenarioTest.java
+++ b/spring-boot/src/test/java/org/dcsa/conformance/manual/ManualScenarioTest.java
@@ -45,6 +45,7 @@ class ManualScenarioTest extends ManualTestBase {
     );
   }
 
+  @Disabled
   @ParameterizedTest(name = "Standard: {0} - 2nd run: {1}")
   @MethodSource("testStandards")
   void testStandards(String standardName, boolean secondRun) {

--- a/spring-boot/src/test/java/org/dcsa/conformance/manual/ManualScenarioTest.java
+++ b/spring-boot/src/test/java/org/dcsa/conformance/manual/ManualScenarioTest.java
@@ -45,7 +45,6 @@ class ManualScenarioTest extends ManualTestBase {
     );
   }
 
-  @Disabled
   @ParameterizedTest(name = "Standard: {0} - 2nd run: {1}")
   @MethodSource("testStandards")
   void testStandards(String standardName, boolean secondRun) {


### PR DESCRIPTION
STNG-25 Replace OpenCSV by plain Java
* OpenCSV is having security issues
* The OpenCSV library is not needed, since we're dealing with simple CSV files atm.
* Added common-text dependency for StringEscapeUtils (not available transitively anymore)