### PR TITLE
STNG-199 Pin dependencies to recent versions

### DIFF
--- a/lambda/pom.xml
+++ b/lambda/pom.xml
@@ -17,18 +17,6 @@
 		<aspectj.version>1.9.21.2</aspectj.version>
 	</properties>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.apache.logging.log4j</groupId>
-				<artifactId>log4j-bom</artifactId>
-				<version>${log4j.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.dcsa.conformance</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,11 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<spring.boot.version>3.3.4</spring.boot.version>
-		<log4j.version>2.20.0</log4j.version>
-		<junit.version>5.11.2</junit.version>
+		<jackson.version>2.18.0</jackson.version>
 		<lombok.version>1.18.34</lombok.version>
+		<log4j.version>2.23.1</log4j.version>
+		<slf4j.version>2.0.16</slf4j.version>
+		<junit.version>5.11.2</junit.version>
 
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<sonar.organization>dcsaorg</sonar.organization>
@@ -126,6 +128,32 @@
 				<groupId>org.dcsa.conformance</groupId>
 				<artifactId>spring-boot</artifactId>
 				<version>${project.version}</version>
+			</dependency>
+
+			<!-- Jackson dependencies -->
+			<dependency>
+				<groupId>com.fasterxml.jackson</groupId>
+				<artifactId>jackson-bom</artifactId>
+				<version>${jackson.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-bom</artifactId>
+				<version>${log4j.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-api</artifactId>
+				<version>${slf4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-codec</groupId>
+				<artifactId>commons-codec</artifactId>
+				<version>1.17.1</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
STNG-199 Pin dependencies to recent versions; prevent deviation in the project

* Use bom imports where possible
* Moved Lambda part to parent, since it could used elsewhere too