### PR TITLE
STNG-8 Add verification and some delay to give actions time to complete

### DIFF
--- a/spring-boot/src/test/java/org/dcsa/conformance/manual/ManualTestBase.java
+++ b/spring-boot/src/test/java/org/dcsa/conformance/manual/ManualTestBase.java
@@ -98,6 +98,8 @@ public abstract class ManualTestBase {
     JsonNode jsonNode = webuiHandler.handleRequest(USER_ID, node);
     assertTrue(jsonNode.isEmpty(), "Should be empty, found: " + jsonNode);
     waitForCleanSandboxStatus(sandbox);
+    waitForAsyncCalls(50L);
+    if (lambdaDelay > 0) waitForAsyncCalls(lambdaDelay * 4);
   }
 
   void validateSandboxScenarioGroup(SandboxConfig sandbox1, String scenarioId, String scenarioName) {
@@ -334,6 +336,7 @@ public abstract class ManualTestBase {
       if (hasPromptText && !jsonNode.get("promptText").textValue().isEmpty()) {
         notifyAction(sandbox2, sandbox1);
       }
+      waitForCleanSandboxStatus(sandbox2);
       if (isRunning) completeAction(sandbox1);
     } while (isRunning);
     validateSandboxScenarioGroup(sandbox1, scenarioId, scenarioName);

--- a/spring-boot/src/test/java/org/dcsa/conformance/manual/ManualTestBase.java
+++ b/spring-boot/src/test/java/org/dcsa/conformance/manual/ManualTestBase.java
@@ -62,6 +62,7 @@ public abstract class ManualTestBase {
             .set("actionInput", textInputNode);
     JsonNode jsonNode = webuiHandler.handleRequest(USER_ID, node);
     assertTrue(jsonNode.isEmpty(), "Should be empty, found: " + jsonNode);
+    if (lambdaDelay > 0) waitForAsyncCalls(lambdaDelay * 6);
     waitForCleanSandboxStatus(sandbox);
   }
 
@@ -83,6 +84,7 @@ public abstract class ManualTestBase {
             .put("operation", "notifyParty")
             .put("sandboxId", sandbox.sandboxId);
     assertTrue(webuiHandler.handleRequest(USER_ID, node).isEmpty());
+    if (lambdaDelay > 0) waitForAsyncCalls(lambdaDelay * 2);
     waitForAsyncCalls(150L);
     waitForCleanSandboxStatus(sandbox);
     waitForCleanSandboxStatus(otherSandbox);

--- a/spring-boot/src/test/java/org/dcsa/conformance/manual/ManualTestBase.java
+++ b/spring-boot/src/test/java/org/dcsa/conformance/manual/ManualTestBase.java
@@ -83,7 +83,7 @@ public abstract class ManualTestBase {
             .put("operation", "notifyParty")
             .put("sandboxId", sandbox.sandboxId);
     assertTrue(webuiHandler.handleRequest(USER_ID, node).isEmpty());
-    waitForAsyncCalls(50L);
+    waitForAsyncCalls(150L);
     waitForCleanSandboxStatus(sandbox);
     waitForCleanSandboxStatus(otherSandbox);
   }


### PR DESCRIPTION
Slower systems need more time after a Notify Action and Complete Action, apparently. The clean sandbox state checking was not enough. 