### PR TITLE
STNG-165 Fix slow Lambda startup

### DIFF
--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -3,6 +3,8 @@ name: Deploy to AWS
 on:
   push:
     branches: ["dev"]
+  pull_request: # DELETE BEFORE MERGE
+    types: [opened, synchronize, reopened]
 
 env:
   AWS_REGION: "eu-north-1"

--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -3,8 +3,6 @@ name: Deploy to AWS
 on:
   push:
     branches: ["dev"]
-  pull_request: # DELETE BEFORE MERGE
-    types: [opened, synchronize, reopened]
 
 env:
   AWS_REGION: "eu-north-1"

--- a/spring-boot/src/test/java/org/dcsa/conformance/frontend/SeleniumTest.java
+++ b/spring-boot/src/test/java/org/dcsa/conformance/frontend/SeleniumTest.java
@@ -23,10 +23,8 @@ class SeleniumTest extends SeleniumTestBase {
 
   @Test
   void testLoginAndCreateSandboxStart() {
+    loginUser();
     driver.get(baseUrl);
-    if (driver.getCurrentUrl().endsWith("/login")) {
-      loginUser();
-    }
     assertEquals(baseUrl + "/environment", driver.getCurrentUrl());
     WebElement createSandbox = driver.findElement(By.id("create_sandbox_button"));
     createSandbox.click();


### PR DESCRIPTION
Some 'Deploy to AWS' tasks failed, after a PR was merged. This is caused by cold starts of Lambda, after a fresh deployment. Giving it a bit more time to warm up. 