### PR TITLE
STNG-210 After sending handleActionInput, check if conformance level progresses

### DIFF
--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/EblScenarioListBuilder.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/EblScenarioListBuilder.java
@@ -119,7 +119,6 @@ class EblScenarioListBuilder extends ScenarioListBuilder<EblScenarioListBuilder>
           "Shipper interactions with transport document",
           carrier_SupplyScenarioParameters(ScenarioType.REGULAR_STRAIGHT_BL)
             .then(_uc6_get(true, _uc7_get(_uc8_get(_uc12_get(_uc13_get()))),
-                _uc8_get(_uc12_get(_uc13_get())),
                 _oob_amendment(_uc6_get(false, _uc8_get(_uc12_get(_uc13_get())))),
                 _uc8_get(_oob_amendment(_uc9_get(_uc10_get(_uc11_get(_uc12_get(_uc13_get()))))))))))
       .collect(

--- a/spring-boot/src/test/java/org/dcsa/conformance/manual/ManualTestBase.java
+++ b/spring-boot/src/test/java/org/dcsa/conformance/manual/ManualTestBase.java
@@ -69,6 +69,15 @@ public abstract class ManualTestBase {
   private void waitUntilScenarioStatusProgresses(SandboxConfig sandbox, String scenarioId, long conformantSubReportsStart) {
     waitForCleanSandboxStatus(sandbox);
 
+    // STNG-210: eBL Issuance, Conformance, uses 2 input prompts, while not progressing conformance.
+    if (sandbox.sandboxName.contains("eBL Issuance")
+      && sandbox.sandboxName.contains("Conformance")
+      && (conformantSubReportsStart == 0)) {
+      waitForAsyncCalls(500L);
+      if (lambdaDelay > 0) waitForAsyncCalls(lambdaDelay * 6);
+      return;
+    }
+
     // Wait until the scenario has finished and is conformant
     int i = 0;
     while (conformantSubReportsStart == countConformantSubReports(sandbox, scenarioId)) {

--- a/spring-boot/src/test/java/org/dcsa/conformance/manual/ManualTestBase.java
+++ b/spring-boot/src/test/java/org/dcsa/conformance/manual/ManualTestBase.java
@@ -74,7 +74,7 @@ public abstract class ManualTestBase {
     // appears to be already conformant.
     if ((sandbox.sandboxName.contains("Ebl")
             && sandbox.sandboxName.contains("Conformance TD-only, Carrier")
-            && (conformantSubReportsStart == 0 || conformantSubReportsStart == 8))
+            && (conformantSubReportsStart == 0))
         || (sandbox.sandboxName.contains("eBL Issuance")
             && sandbox.sandboxName.contains("Conformance")
             && (conformantSubReportsStart == 0))) {

--- a/spring-boot/src/test/java/org/dcsa/conformance/manual/ManualTestBase.java
+++ b/spring-boot/src/test/java/org/dcsa/conformance/manual/ManualTestBase.java
@@ -69,9 +69,8 @@ public abstract class ManualTestBase {
   private void waitUntilScenarioStatusProgresses(SandboxConfig sandbox, String scenarioId, long conformantSubReportsStart) {
     waitForCleanSandboxStatus(sandbox);
 
-    // STNG-210: EBL Conformance TD-only, Carrier UC6 uses 2 input prompts, while not progressing conformance.
-    // 'conformantSubReportsStart = 8' is a workaround for 'SupplyCSP [REGULAR_STRAIGHT_BL] - UC6'
-    // appears to be already conformant.
+    // STNG-210: Ebl Conformance TD-only, Carrier UC6 uses 2 input prompts, while not progressing conformance.
+    // STNG-210: eBL Issuance, Conformance, uses 2 input prompts, while not progressing conformance.
     if ((sandbox.sandboxName.contains("Ebl")
             && sandbox.sandboxName.contains("Conformance TD-only, Carrier")
             && (conformantSubReportsStart == 0))


### PR DESCRIPTION
STNG-210 After sending handleActionInput, check if conformance level progresses
* Also check for `inputRequired`, to stop waiting and proceed to the next step
* Workaround for EBL Issuance is in place, until that standard is revisited. 

Also added some useful sandbox details, if a Selenium tests fails on conformance issues (did not happen before, so just saw that this is missing). 