### PR TITLE
SD-1775: Issues with parsing the provided public key

### DIFF
--- a/ebl/pom.xml
+++ b/ebl/pom.xml
@@ -33,5 +33,15 @@
 			<artifactId>canonical-json</artifactId>
 			<version>3.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcprov-jdk18on</artifactId>
+			<version>1.79</version>
+		</dependency>
+		<dependency>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcpkix-jdk18on</artifactId>
+			<version>1.79</version>
+		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
The real issue was the header used `RSA `, when it should not have. However, I also changed the code to use Bouncycastle's PEM parser and writer to delegate some of the code to a library.