### PR TITLE
SD-603 Update PartyFunction EBL

### DIFF
--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EBLChecks.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EBLChecks.java
@@ -670,13 +670,13 @@ public class EBLChecks {
 
   static final JsonRebaseableContentCheck VALID_PARTY_FUNCTION =
       JsonAttribute.allIndividualMatchesMustBeValid(
-          "The partyFunction is valid",
+          "The partyFunction in OtherDocumentParty is valid",
           mav -> mav.submitAllMatching("documentParties.other.*.partyFunction"),
           JsonAttribute.matchedMustBeDatasetKeywordIfPresent(PARTY_FUNCTION_CODE));
 
   static final JsonRebaseableContentCheck VALID_PARTY_FUNCTION_HBL =
       JsonAttribute.allIndividualMatchesMustBeValid(
-          "The partyFunction in houseBillOfLadings is valid",
+          "The partyFunction in OtherDocumentParty of houseBillOfLadings is valid",
           mav ->
               mav.submitAllMatching("houseBillOfLadings.*.documentParties.other.*.partyFunction"),
           JsonAttribute.matchedMustBeDatasetKeywordIfPresent(PARTY_FUNCTION_CODE_HBL));

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EBLChecks.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EBLChecks.java
@@ -5,6 +5,8 @@ import static org.dcsa.conformance.standards.ebl.checks.EblDatasets.DOCUMENTATIO
 import static org.dcsa.conformance.standards.ebl.checks.EblDatasets.EXEMPT_PACKAGE_CODES;
 import static org.dcsa.conformance.standards.ebl.checks.EblDatasets.MODE_OF_TRANSPORT;
 import static org.dcsa.conformance.standards.ebl.checks.EblDatasets.NATIONAL_COMMODITY_CODES;
+import static org.dcsa.conformance.standards.ebl.checks.EblDatasets.PARTY_FUNCTION_CODE;
+import static org.dcsa.conformance.standards.ebl.checks.EblDatasets.PARTY_FUNCTION_CODE_HBL;
 import static org.dcsa.conformance.standards.ebl.checks.EblDatasets.REQUESTED_CARRIER_CLAUSES;
 
 
@@ -666,6 +668,19 @@ public class EBLChecks {
               JsonAttribute.mustBeAbsent(SI_REQUEST_SEND_TO_PLATFORM)),
           JsonAttribute.mustBeAbsent(SI_REQUEST_SEND_TO_PLATFORM));
 
+  static final JsonRebaseableContentCheck VALID_PARTY_FUNCTION =
+      JsonAttribute.allIndividualMatchesMustBeValid(
+          "The partyFunction is valid",
+          mav -> mav.submitAllMatching("documentParties.other.*.partyFunction"),
+          JsonAttribute.matchedMustBeDatasetKeywordIfPresent(PARTY_FUNCTION_CODE));
+
+  static final JsonRebaseableContentCheck VALID_PARTY_FUNCTION_HBL =
+      JsonAttribute.allIndividualMatchesMustBeValid(
+          "The partyFunction in houseBillOfLadings is valid",
+          mav ->
+              mav.submitAllMatching("houseBillOfLadings.*.documentParties.other.*.partyFunction"),
+          JsonAttribute.matchedMustBeDatasetKeywordIfPresent(PARTY_FUNCTION_CODE_HBL));
+
   private static final List<JsonContentCheck> STATIC_SI_CHECKS = Arrays.asList(
     JsonAttribute.mustBeDatasetKeywordIfPresent(
       SI_REQUEST_SEND_TO_PLATFORM,
@@ -684,6 +699,8 @@ public class EBLChecks {
     ROUTING_OF_CONSIGNMENT_COUNTRIES_CHECK,
     VALID_REQUESTED_CARRIER_CLAUSES,
     BUYER_AND_SELLER_CONDITIONAL_CHECK,
+    VALID_PARTY_FUNCTION,
+    VALID_PARTY_FUNCTION_HBL,
     ONLY_EBLS_CAN_BE_NEGOTIABLE,
     EBL_AT_MOST_ONE_COPY_WITHOUT_CHARGES,
     EBL_AT_MOST_ONE_COPY_WITH_CHARGES,
@@ -811,7 +828,8 @@ public class EBLChecks {
       JsonAttribute.matchedMustBeDatasetKeywordIfPresent(MODE_OF_TRANSPORT)
     ),
     NOTIFY_PARTIES_REQUIRED_IN_NEGOTIABLE_BLS,
-    TLR_CC_T_COMBINATION_UNIQUE
+    TLR_CC_T_COMBINATION_UNIQUE,
+    VALID_PARTY_FUNCTION
   );
 
   public static final JsonContentCheck SIR_REQUIRED_IN_NOTIFICATION = JsonAttribute.mustBePresent(SI_NOTIFICATION_SIR_PTR);

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EblDatasets.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EblDatasets.java
@@ -92,4 +92,8 @@ public class EblDatasets {
     "INTRANSITCLAUSE"
   );
 
+  public static final KeywordDataset PARTY_FUNCTION_CODE =
+      KeywordDataset.staticDataset("SCO", "DDR", "DDS", "COW", "COX", "CS", "MF", "WH");
+  public static final KeywordDataset PARTY_FUNCTION_CODE_HBL =
+      KeywordDataset.staticDataset("DDR", "DDS", "CS", "MF", "WH");
 }

--- a/ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-request.json
+++ b/ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-request.json
@@ -148,7 +148,7 @@
     },
     "issueTo": {
       "partyName": "DCSA CTK",
-      "identifyingCodes" : [
+      "identifyingCodes": [
         {
           "codeListProvider": "W3C",
           "codeListName": "LCL",

--- a/ebl/src/test/java/org/dcsa/conformance/standards/ebl/checks/EBLChecksTest.java
+++ b/ebl/src/test/java/org/dcsa/conformance/standards/ebl/checks/EBLChecksTest.java
@@ -19,6 +19,8 @@ import static org.dcsa.conformance.standards.ebl.checks.EBLChecks.COUNTRY_CODE_C
 import static org.dcsa.conformance.standards.ebl.checks.EBLChecks.LOCATION_NAME_CONDITIONAL_VALIDATION_POA;
 import static org.dcsa.conformance.standards.ebl.checks.EBLChecks.LOCATION_NAME_CONDITIONAL_VALIDATION_POFD;
 import static org.dcsa.conformance.standards.ebl.checks.EBLChecks.VALID_CONSIGMENT_ITEMS_REFERENCE_TYPES;
+import static org.dcsa.conformance.standards.ebl.checks.EBLChecks.VALID_PARTY_FUNCTION;
+import static org.dcsa.conformance.standards.ebl.checks.EBLChecks.VALID_PARTY_FUNCTION_HBL;
 import static org.dcsa.conformance.standards.ebl.checks.EBLChecks.VALID_REQUESTED_CARRIER_CLAUSES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -294,5 +296,37 @@ class EBLChecksTest {
     references.addObject().put("type", "CRR");
     Set<String> invalidErrors = VALID_CONSIGMENT_ITEMS_REFERENCE_TYPES.validate(rootNode);
     assertEquals(1, invalidErrors.size());
+  }
+
+  @Test
+  void testValidPartyFunction() {
+    ObjectNode documentParties = rootNode.putObject("documentParties");
+    ArrayNode otherParties = documentParties.putArray("other");
+    ObjectNode otherParty = otherParties.addObject();
+    otherParty.put("partyFunction", "SCO");
+
+    Set<String> errors = VALID_PARTY_FUNCTION.validate(rootNode);
+    assertEquals(0, errors.size());
+
+    otherParty.put("partyFunction", "SSS");
+    errors = VALID_PARTY_FUNCTION.validate(rootNode);
+    assertEquals(1, errors.size());
+  }
+
+  @Test
+  void testValidPartyFunctionHBL() {
+    ArrayNode houseBillOfLadings = rootNode.putArray("houseBillOfLadings");
+    ObjectNode hbl = houseBillOfLadings.addObject();
+    ObjectNode documentParties = hbl.putObject("documentParties");
+    ArrayNode otherParties = documentParties.putArray("other");
+    ObjectNode otherParty = otherParties.addObject();
+    otherParty.put("partyFunction", "CS");
+
+    Set<String> errors = VALID_PARTY_FUNCTION_HBL.validate(rootNode);
+    assertEquals(0, errors.size());
+
+    otherParty.put("partyFunction", "SSS");
+    errors = VALID_PARTY_FUNCTION_HBL.validate(rootNode);
+    assertEquals(1, errors.size());
   }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added validation for party function codes in EBL documents:
  * Main document supports codes: SCO, DDR, DDS, COW, COX, CS, MF, WH
  * House bill of ladings supports codes: DDR, DDS, CS, MF, WH
- Implemented validation checks in EBLChecks class for both document types
- Added comprehensive unit tests to verify party function validation
- Minor formatting improvements in API request schema



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EBLChecks.java</strong><dd><code>Add party function code validation checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EBLChecks.java

<li>Added validation checks for party function codes in both main document <br>and house bill of ladings<br> <li> Added new checks to static SI checks list<br> <li> Updated transport mode validation<br>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/243/files#diff-e45bcf9f51c94f0c72632f7a40f04a3bb184896801843c0c97cf4a4dad1ee8a8">+19/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EblDatasets.java</strong><dd><code>Define party function code datasets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EblDatasets.java

<li>Added new KeywordDataset constants for party function codes<br> <li> Defined valid party function codes for main document and house bill of <br>ladings<br>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/243/files#diff-cf98df85588aa7b9a52011751dbb93ad55da645327edf82e93832b773104f0fa">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EBLChecksTest.java</strong><dd><code>Add party function validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl/src/test/java/org/dcsa/conformance/standards/ebl/checks/EBLChecksTest.java

<li>Added unit tests for party function validation<br> <li> Added test cases for both main document and house bill of ladings <br>party functions<br>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/243/files#diff-8321040c2df3048dfaa74a4394bd1951e59d17f4974c57841d084ffe6b8feea7">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ebl-api-3.0.0-request.json</strong><dd><code>Fix JSON formatting in API request schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-request.json

- Minor formatting fix in identifyingCodes property



</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/243/files#diff-3e1f83a80cfe7f82a7dd949377b6c9f7ae42db4c8bb5c147ed696506f65fbf7e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information