### PR TITLE
SD-1939-Rename commoditySubreference to commoditySubReference in Booking and Ebl

### DIFF
--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/checks/BookingChecks.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/checks/BookingChecks.java
@@ -249,7 +249,7 @@ public class BookingChecks {
   private static final JsonContentCheck COMMODITIES_SUBREFERENCE_UNIQUE = JsonAttribute.allIndividualMatchesMustBeValid(
     "Each Subreference in commodities must be unique",
     mav -> mav.submitAllMatching("requestedEquipments.*.commodities"),
-    JsonAttribute.unique("commoditySubreference")
+    JsonAttribute.unique("commoditySubReference")
   );
 
   private static final JsonContentCheck VALIDATE_ALLOWED_SHIPMENT_CUTOFF_CODE = JsonAttribute.allIndividualMatchesMustBeValid(
@@ -769,12 +769,12 @@ public class BookingChecks {
         CARRIER_BOOKING_REFERENCE
       ));
       checks.add(JsonAttribute.allIndividualMatchesMustBeValid(
-          "The commoditySubreference is not present for confirmed booking",
+          "The commoditySubReference is not present for confirmed booking",
           mav -> mav.submitAllMatching("requestedEquipments.*.commodities.*"),
           (nodeToValidate, contextPath) -> {
-            var commoditySubreference = nodeToValidate.path("commoditySubreference");
-            if (commoditySubreference.isMissingNode() || commoditySubreference.isNull()) {
-              return Set.of("The commoditySubreference at %s is not present for confirmed booking".formatted(contextPath));
+            var commoditySubReference = nodeToValidate.path("commoditySubReference");
+            if (commoditySubReference.isMissingNode() || commoditySubReference.isNull()) {
+              return Set.of("The commoditySubReference at %s is not present for confirmed booking".formatted(contextPath));
             }
             return Set.of();
           }

--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/model/PersistableCarrierBooking.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/model/PersistableCarrierBooking.java
@@ -527,7 +527,7 @@ public class PersistableCarrierBooking {
         var commoditiesNode = (ArrayNode) requestedEquipment.get("commodities");
         if (commoditiesNode != null && commoditiesNode.isArray()) {
           for(var commodity: commoditiesNode) {
-            ((ObjectNode)commodity).put("commoditySubreference", "COM"+commoditySubReferenceSequence++);
+            ((ObjectNode)commodity).put("commoditySubReference", "COM"+commoditySubReferenceSequence++);
           }
         }
         confirmedEquipments.addObject().put("ISOEquipmentCode", equipmentCode).put("units", units);

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EBLChecks.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EBLChecks.java
@@ -771,8 +771,8 @@ public class EBLChecks {
     NOR_PLUS_ISO_CODE_IMPLIES_ACTIVE_REEFER,
     NOR_IS_TRUE_IMPLIES_NO_ACTIVE_REEFER,
     JsonAttribute.allIndividualMatchesMustBeValid(
-      "The 'commoditySubreference' must not be present in the transport document",
-      mav -> mav.submitAllMatching("consignmentItems.*.commoditySubreference"),
+      "The 'commoditySubReference' must not be present in the transport document",
+      mav -> mav.submitAllMatching("consignmentItems.*.commoditySubReference"),
       JsonAttribute.matchedMustBeAbsent()
     ),
     JsonAttribute.allIndividualMatchesMustBeValid(
@@ -883,7 +883,7 @@ public class EBLChecks {
         ));
       checks.add(
         JsonAttribute.customValidator(
-          "[Scenario] Verify that the correct 'commoditySubreference' is used",
+          "[Scenario] Verify that the correct 'commoditySubReference' is used",
           JsonAttribute.path(CONSIGNMENT_ITEMS, checkCommoditySubreference(cspSupplier))));
 
       checks.add(
@@ -1146,10 +1146,10 @@ public class EBLChecks {
   private static JsonContentMatchedValidation checkCommoditySubreference(Supplier<CarrierScenarioParameters> cspSupplier) {
     Supplier<Set<String>> expectedValueSupplier = () -> {
       var csp = cspSupplier.get();
-      return setOf(csp.commoditySubreference(), csp.commoditySubreference2());
+      return setOf(csp.commoditySubReference(), csp.commoditySubReference2());
     };
     return checkCSPAllUsedAtLeastOnce(
-      "commoditySubreference",
+      "commoditySubReference",
       expectedValueSupplier
     );
   }
@@ -1159,10 +1159,10 @@ public class EBLChecks {
       var csp = cspSupplier.get();
       var m = new LinkedHashMap<String, String>();
       if (csp.descriptionOfGoods() != null) {
-        m.put(csp.descriptionOfGoods(), csp.commoditySubreference());
+        m.put(csp.descriptionOfGoods(), csp.commoditySubReference());
       }
       if (csp.descriptionOfGoods2() != null) {
-        m.put(csp.descriptionOfGoods2(), csp.commoditySubreference2());
+        m.put(csp.descriptionOfGoods2(), csp.commoditySubReference2());
       }
       return m;
     };
@@ -1177,7 +1177,7 @@ public class EBLChecks {
     };
     return checkCSPValueBasedOnOtherValue(
       "descriptionOfGoods",
-      "commoditySubreference",
+      "commoditySubReference",
       expectedValueSupplier,
       resolver
     );
@@ -1188,10 +1188,10 @@ public class EBLChecks {
       var csp = cspSupplier.get();
       var m = new LinkedHashMap<String, String>();
       if (csp.descriptionOfGoods() != null) {
-        m.put(csp.consignmentItemHSCode(), csp.commoditySubreference());
+        m.put(csp.consignmentItemHSCode(), csp.commoditySubReference());
       }
       if (csp.descriptionOfGoods2() != null) {
-        m.put(csp.consignmentItem2HSCode(), csp.commoditySubreference2());
+        m.put(csp.consignmentItem2HSCode(), csp.commoditySubReference2());
       }
       return m;
     };
@@ -1206,7 +1206,7 @@ public class EBLChecks {
     };
     return checkCSPValueBasedOnOtherValue(
       "HSCodes",
-      "commoditySubreference",
+      "commoditySubReference",
       expectedValueSupplier,
       resolver
     );

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/models/CarrierShippingInstructions.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/models/CarrierShippingInstructions.java
@@ -223,7 +223,7 @@ public class CarrierShippingInstructions {
     Map.entry("3.0.0",  (transportDocument, scenarioType) -> {
       for (var consignmentItemNode : transportDocument.path("consignmentItems")) {
         if (consignmentItemNode instanceof ObjectNode consignmentItem) {
-          consignmentItem.remove("commoditySubreference");
+          consignmentItem.remove("commoditySubReference");
         }
         for (var cargoItemNode : consignmentItemNode.path("cargoItems")) {
           if (!scenarioType.hasDG() || !cargoItemNode.isObject()) {

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/party/CarrierScenarioParameters.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/party/CarrierScenarioParameters.java
@@ -8,8 +8,8 @@ import org.dcsa.conformance.core.party.ScenarioParameters;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CarrierScenarioParameters(
     String carrierBookingReference,
-    String commoditySubreference,
-    String commoditySubreference2,
+    String commoditySubReference,
+    String commoditySubReference2,
     String equipmentReference,
     String equipmentReference2,
     String invoicePayableAtUNLocationCode,
@@ -23,8 +23,8 @@ public record CarrierScenarioParameters(
   public static CarrierScenarioParameters fromJson(JsonNode jsonNode) {
     return new CarrierScenarioParameters(
       jsonNode.required("carrierBookingReference").asText(),
-      jsonNode.path("commoditySubreference").asText(null),
-      jsonNode.path("commoditySubreference2").asText(null),
+      jsonNode.path("commoditySubReference").asText(null),
+      jsonNode.path("commoditySubReference2").asText(null),
       jsonNode.path("equipmentReference").asText(null),
       jsonNode.path("equipmentReference2").asText(null),
       jsonNode.required("invoicePayableAtUNLocationCode").asText(),

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/party/EblShipper.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/party/EblShipper.java
@@ -81,10 +81,10 @@ public class EblShipper extends ConformanceParty {
             carrierScenarioParameters.carrierBookingReference()),
           Map.entry(
             "COMMODITY_SUBREFERENCE_PLACEHOLDER",
-            Objects.requireNonNullElse(carrierScenarioParameters.commoditySubreference(), "")),
+            Objects.requireNonNullElse(carrierScenarioParameters.commoditySubReference(), "")),
           Map.entry(
             "COMMODITY_SUBREFERENCE_2_PLACEHOLDER",
-            Objects.requireNonNullElse(carrierScenarioParameters.commoditySubreference2(), "")),
+            Objects.requireNonNullElse(carrierScenarioParameters.commoditySubReference2(), "")),
           Map.entry(
             "EQUIPMENT_REFERENCE_PLACEHOLDER",
             Objects.requireNonNullElse(carrierScenarioParameters.equipmentReference(), "")),

--- a/ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-2c2u1e.json
+++ b/ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-2c2u1e.json
@@ -21,7 +21,7 @@
       "HSCodes": [
         "CONSIGNMENT_ITEM_HS_CODE"
       ],
-      "commoditySubreference": "COMMODITY_SUBREFERENCE_PLACEHOLDER",
+      "commoditySubReference": "COMMODITY_SUBREFERENCE_PLACEHOLDER",
       "cargoItems": [
         {
           "equipmentReference": "EQUIPMENT_REFERENCE_PLACEHOLDER",
@@ -42,7 +42,7 @@
       "HSCodes": [
         "CONSIGNMENT_ITEM_2_HS_CODE"
       ],
-      "commoditySubreference": "COMMODITY_SUBREFERENCE_2_PLACEHOLDER",
+      "commoditySubReference": "COMMODITY_SUBREFERENCE_2_PLACEHOLDER",
       "cargoItems": [
         {
           "equipmentReference": "EQUIPMENT_REFERENCE_2_PLACEHOLDER",

--- a/ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-2c2u2e.json
+++ b/ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-2c2u2e.json
@@ -21,7 +21,7 @@
       "HSCodes": [
         "CONSIGNMENT_ITEM_HS_CODE"
       ],
-      "commoditySubreference": "COMMODITY_SUBREFERENCE_PLACEHOLDER",
+      "commoditySubReference": "COMMODITY_SUBREFERENCE_PLACEHOLDER",
       "cargoItems": [
         {
           "equipmentReference": "EQUIPMENT_REFERENCE_PLACEHOLDER",
@@ -53,7 +53,7 @@
       "HSCodes": [
         "CONSIGNMENT_ITEM_2_HS_CODE"
       ],
-      "commoditySubreference": "COMMODITY_SUBREFERENCE_2_PLACEHOLDER",
+      "commoditySubReference": "COMMODITY_SUBREFERENCE_2_PLACEHOLDER",
       "cargoItems": [
         {
           "equipmentReference": "EQUIPMENT_REFERENCE_PLACEHOLDER",

--- a/ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-amf.json
+++ b/ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-amf.json
@@ -21,7 +21,7 @@
       "HSCodes": [
         "CONSIGNMENT_ITEM_HS_CODE"
       ],
-      "commoditySubreference": "COMMODITY_SUBREFERENCE_PLACEHOLDER",
+      "commoditySubReference": "COMMODITY_SUBREFERENCE_PLACEHOLDER",
       "cargoItems": [
         {
           "equipmentReference": "EQUIPMENT_REFERENCE_PLACEHOLDER",

--- a/ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-clad.json
+++ b/ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-clad.json
@@ -29,7 +29,7 @@
       "HSCodes": [
         "CONSIGNMENT_ITEM_HS_CODE"
       ],
-      "commoditySubreference": "COMMODITY_SUBREFERENCE_PLACEHOLDER",
+      "commoditySubReference": "COMMODITY_SUBREFERENCE_PLACEHOLDER",
       "cargoItems": [
         {
           "equipmentReference": "EQUIPMENT_REFERENCE_PLACEHOLDER",

--- a/ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-dg.json
+++ b/ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-dg.json
@@ -22,7 +22,7 @@
       "HSCodes": [
         "CONSIGNMENT_ITEM_HS_CODE"
       ],
-      "commoditySubreference": "COMMODITY_SUBREFERENCE_PLACEHOLDER",
+      "commoditySubReference": "COMMODITY_SUBREFERENCE_PLACEHOLDER",
       "cargoItems": [
         {
           "equipmentReference": "EQUIPMENT_REFERENCE_PLACEHOLDER",

--- a/ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-negotiable-bl.json
+++ b/ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-negotiable-bl.json
@@ -28,7 +28,7 @@
       "HSCodes": [
         "CONSIGNMENT_ITEM_HS_CODE"
       ],
-      "commoditySubreference": "COMMODITY_SUBREFERENCE_PLACEHOLDER",
+      "commoditySubReference": "COMMODITY_SUBREFERENCE_PLACEHOLDER",
       "cargoItems": [
         {
           "equipmentReference": "EQUIPMENT_REFERENCE_PLACEHOLDER",

--- a/ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-request.json
+++ b/ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-request.json
@@ -28,7 +28,7 @@
       "HSCodes": [
         "CONSIGNMENT_ITEM_HS_CODE"
       ],
-      "commoditySubreference": "COMMODITY_SUBREFERENCE_PLACEHOLDER",
+      "commoditySubReference": "COMMODITY_SUBREFERENCE_PLACEHOLDER",
       "cargoItems": [
         {
           "equipmentReference": "EQUIPMENT_REFERENCE_PLACEHOLDER",
@@ -110,7 +110,7 @@
           "HSCodes": [
             "CONSIGNMENT_ITEM_HS_CODE"
           ],
-          "commoditySubreference": "COMMODITY_SUBREFERENCE_PLACEHOLDER",
+          "commoditySubReference": "COMMODITY_SUBREFERENCE_PLACEHOLDER",
           "cargoItems": [
             {
               "equipmentReference": "EQUIPMENT_REFERENCE_PLACEHOLDER",

--- a/ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-soc-references.json
+++ b/ebl/src/main/resources/standards/ebl/messages/ebl-api-3.0.0-soc-references.json
@@ -21,7 +21,7 @@
       "HSCodes": [
         "CONSIGNMENT_ITEM_HS_CODE"
       ],
-      "commoditySubreference": "COMMODITY_SUBREFERENCE_PLACEHOLDER",
+      "commoditySubReference": "COMMODITY_SUBREFERENCE_PLACEHOLDER",
       "cargoItems": [
         {
           "equipmentReference": "ABCU7341935",


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Standardized the casing of `commoditySubReference` across multiple files.

- Updated validation logic to reflect the corrected casing.

- Adjusted JSON templates to use `commoditySubReference` consistently.

- Improved conformance checks for booking and eBL standards.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>BookingChecks.java</strong><dd><code>Corrected casing for `commoditySubReference` in booking checks</code></dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/248/files#diff-49081d349f9f79c3b4fefee92a966e1e0cd11560093ef529cffa9df7d2991f07">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PersistableCarrierBooking.java</strong><dd><code>Updated `commoditySubReference` casing in booking model</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/248/files#diff-1c19ab1788ef8d27fe31d7d47da2387257b6eee42abcce3ac5bd0d36a4741f25">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EBLChecks.java</strong><dd><code>Fixed `commoditySubReference` casing in eBL checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/248/files#diff-e45bcf9f51c94f0c72632f7a40f04a3bb184896801843c0c97cf4a4dad1ee8a8">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CarrierShippingInstructions.java</strong><dd><code>Removed <code>commoditySubReference</code> with corrected casing in shipping <br>instructions</code></dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/248/files#diff-6ae683425ccd8c88d013b97c5df91b39dcf695c46498372b8f33787ee5d04653">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CarrierScenarioParameters.java</strong><dd><code>Updated `commoditySubReference` casing in carrier scenario parameters</code></dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/248/files#diff-692e1b8e32a894047ede5b09468d0676882a4313381363fd34f689c148dee3c0">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EblShipper.java</strong><dd><code>Corrected `commoditySubReference` casing in EBL shipper logic</code></dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/248/files#diff-fe0bf3d1c7ba79cc3bf0c9389142fbae69d1ddd7ad4dd3c80058a4c2bbaefc78">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ebl-api-3.0.0-2c2u1e.json</strong><dd><code>Adjusted JSON template for `commoditySubReference` casing</code></dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/248/files#diff-0162cb8ac14b3bcbd1386581ffbb59820091d156ec8091ac9fe7cd631ee3ebf1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ebl-api-3.0.0-2c2u2e.json</strong><dd><code>Updated JSON template for `commoditySubReference` casing</code>&nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/248/files#diff-fd7ac67cc29ad0d850adcfb07ac66f7ab77710da863dc44816f6ebd6379494d0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ebl-api-3.0.0-amf.json</strong><dd><code>Fixed `commoditySubReference` casing in AMF JSON template</code></dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/248/files#diff-861044e6166de0c6ddf99aa20eaf7236292fb0a571df03d46332c00aa10d8c58">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ebl-api-3.0.0-clad.json</strong><dd><code>Corrected `commoditySubReference` casing in CLAD JSON template</code></dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/248/files#diff-08a554affd1bd1f92b2c69b96b76f5aa4cd82fae046db05ea7c82bb81a776bb1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ebl-api-3.0.0-dg.json</strong><dd><code>Updated `commoditySubReference` casing in DG JSON template</code></dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/248/files#diff-828774e1611f0730ef95beb81fbdeb33d8710e26b019f57b4c3e326b2169dbf0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ebl-api-3.0.0-negotiable-bl.json</strong><dd><code>Fixed `commoditySubReference` casing in negotiable BL JSON template</code></dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/248/files#diff-182d35d1b06600674bf85eb899e3086b2e65c3ba9bc27722a3080b2537266c06">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ebl-api-3.0.0-request.json</strong><dd><code>Corrected `commoditySubReference` casing in request JSON template</code></dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/248/files#diff-3e1f83a80cfe7f82a7dd949377b6c9f7ae42db4c8bb5c147ed696506f65fbf7e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ebl-api-3.0.0-soc-references.json</strong><dd><code>Adjusted <code>commoditySubReference</code> casing in SOC references JSON template</code></dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/248/files#diff-5551fc6971c9890c91b997f1cbb8034a9405a293eabb7b1ea1f5fc49c8e29b94">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information