### PR TITLE
Bug improve issuance pint cert prompts

### DIFF
--- a/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/action/CarrierScenarioParametersAction.java
+++ b/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/action/CarrierScenarioParametersAction.java
@@ -62,7 +62,7 @@ public class CarrierScenarioParametersAction extends IssuanceAction {
   public void handlePartyInput(JsonNode partyInput) {
     CarrierScenarioParameters carrierScenarioParameters = CarrierScenarioParameters.fromJson(partyInput.get("input"));
     // validate the carrier signing key
-    PayloadSignerFactory.verifierFromPemEncodedPublicKey(carrierScenarioParameters.carrierSigningKeyPEM());
+    PayloadSignerFactory.verifierFromPemEncodedPublicKey(carrierScenarioParameters.carriersX509SigningCertificateInPEMFormat());
     getCspConsumer().accept(carrierScenarioParameters);
   }
 

--- a/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/action/CarrierScenarioParametersAction.java
+++ b/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/action/CarrierScenarioParametersAction.java
@@ -62,7 +62,10 @@ public class CarrierScenarioParametersAction extends IssuanceAction {
   public void handlePartyInput(JsonNode partyInput) {
     CarrierScenarioParameters carrierScenarioParameters = CarrierScenarioParameters.fromJson(partyInput.get("input"));
     // validate the carrier signing key
-    PayloadSignerFactory.verifierFromPemEncodedPublicKey(carrierScenarioParameters.carriersX509SigningCertificateInPEMFormat());
+    PayloadSignerFactory.verifierFromPemEncodedCertificate(
+      carrierScenarioParameters.carriersX509SigningCertificateInPEMFormat(),
+      "carriersX509SigningCertificateInPEMFormat"
+    );
     getCspConsumer().accept(carrierScenarioParameters);
   }
 

--- a/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/action/IssuanceRequestResponseAction.java
+++ b/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/action/IssuanceRequestResponseAction.java
@@ -154,8 +154,9 @@ public class IssuanceRequestResponseAction extends IssuanceAction {
       protected Stream<? extends ConformanceCheck> createSubChecks() {
         Supplier<SignatureVerifier> signatureVerifier =
             () ->
-                PayloadSignerFactory.verifierFromPemEncodedPublicKey(
-                    getCspSupplier().get().carriersX509SigningCertificateInPEMFormat());
+              PayloadSignerFactory.verifierFromPemEncodedCertificate(
+                getCspSupplier().get().carriersX509SigningCertificateInPEMFormat(),
+                "carriersX509SigningCertificateInPEMFormat");
         String asyncResponseChecksPrefix = "[Response]";
         UUID matchedExchangeUuid = getMatchedExchangeUuid();
         UUID matchedNotificationExchangeUuid = getMatchedNotificationExchangeUuid();

--- a/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/action/IssuanceRequestResponseAction.java
+++ b/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/action/IssuanceRequestResponseAction.java
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.dcsa.conformance.core.check.*;
 import org.dcsa.conformance.core.traffic.ConformanceExchange;
 import org.dcsa.conformance.core.traffic.HttpMessageType;
-import org.dcsa.conformance.standards.ebl.checks.SignatureChecks;
 import org.dcsa.conformance.standards.ebl.crypto.PayloadSignerFactory;
 import org.dcsa.conformance.standards.ebl.crypto.SignatureVerifier;
 import org.dcsa.conformance.standards.eblissuance.checks.IssuanceChecks;
@@ -156,7 +155,7 @@ public class IssuanceRequestResponseAction extends IssuanceAction {
         Supplier<SignatureVerifier> signatureVerifier =
             () ->
                 PayloadSignerFactory.verifierFromPemEncodedPublicKey(
-                    getCspSupplier().get().carrierSigningKeyPEM());
+                    getCspSupplier().get().carriersX509SigningCertificateInPEMFormat());
         String asyncResponseChecksPrefix = "[Response]";
         UUID matchedExchangeUuid = getMatchedExchangeUuid();
         UUID matchedNotificationExchangeUuid = getMatchedNotificationExchangeUuid();

--- a/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/party/CarrierScenarioParameters.java
+++ b/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/party/CarrierScenarioParameters.java
@@ -5,7 +5,7 @@ import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.dcsa.conformance.core.party.ScenarioParameters;
 
-public record CarrierScenarioParameters(String carrierSigningKeyPEM) implements ScenarioParameters {
+public record CarrierScenarioParameters(String carriersX509SigningCertificateInPEMFormat) implements ScenarioParameters {
 
   public static CarrierScenarioParameters fromJson(JsonNode jsonNode) {
     return OBJECT_MAPPER.convertValue(jsonNode, CarrierScenarioParameters.class);

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/PayloadSignerFactory.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/PayloadSignerFactory.java
@@ -197,7 +197,11 @@ public class PayloadSignerFactory {
       if (publicKey instanceof ECPublicKey ecPublicKey) {
         return new SingleKeySignatureVerifier(new ECDSAVerifier(ecPublicKey));
       }
-      throw new UserFacingException("Unsupported public key; must be a RSAPublicKey or an ECPublicKey.");
+      // We only accept RSA and ECDHE based algorithms due to the JWS standard.
+      // However, X.509 can support other key algorithms. This exception is for
+      // when users provide certificates with keys beyond what is supposed by
+      // JWS.
+      throw new UserFacingException("Unsupported certificate/public key. The underlying public key must be a RSAPublicKey or an ECPublicKey.");
     }
 
     @SneakyThrows

--- a/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/action/PintAction.java
+++ b/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/action/PintAction.java
@@ -56,17 +56,17 @@ public abstract class PintAction extends ConformanceAction {
 
   public SignatureVerifier resolveSignatureVerifierSenderSignatures() {
     var pem = getSsp().sendersX509SigningCertificateInPEMFormat();
-    return PayloadSignerFactory.verifierFromPemEncodedPublicKey(pem);
+    return PayloadSignerFactory.verifierFromPemEncodedCertificate(pem, "sendersX509SigningCertificateInPEMFormat");
   }
 
   public SignatureVerifier resolveSignatureVerifierCarrierSignatures() {
     var pem = getSsp().carriersX509SigningCertificateInPEMFormat();
-    return PayloadSignerFactory.verifierFromPemEncodedPublicKey(pem);
+    return PayloadSignerFactory.verifierFromPemEncodedCertificate(pem, "carriersX509SigningCertificateInPEMFormat");
   }
 
   public SignatureVerifier resolveSignatureVerifierForReceiverSignatures() {
     var pem = getRsp().receiversX509SigningCertificateInPEMFormat();
-    return PayloadSignerFactory.verifierFromPemEncodedPublicKey(pem);
+    return PayloadSignerFactory.verifierFromPemEncodedCertificate(pem, "receiversX509SigningCertificateInPEMFormat");
   }
 
   @Override

--- a/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/action/PintAction.java
+++ b/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/action/PintAction.java
@@ -55,17 +55,17 @@ public abstract class PintAction extends ConformanceAction {
 
 
   public SignatureVerifier resolveSignatureVerifierSenderSignatures() {
-    var pem = getSsp().senderPublicKeyPEM();
+    var pem = getSsp().sendersX509SigningCertificateInPEMFormat();
     return PayloadSignerFactory.verifierFromPemEncodedPublicKey(pem);
   }
 
   public SignatureVerifier resolveSignatureVerifierCarrierSignatures() {
-    var pem = getSsp().carrierPublicKeyPEM();
+    var pem = getSsp().carriersX509SigningCertificateInPEMFormat();
     return PayloadSignerFactory.verifierFromPemEncodedPublicKey(pem);
   }
 
   public SignatureVerifier resolveSignatureVerifierForReceiverSignatures() {
-    var pem = getRsp().receiverPublicKeyPEM();
+    var pem = getRsp().receiversX509SigningCertificateInPEMFormat();
     return PayloadSignerFactory.verifierFromPemEncodedPublicKey(pem);
   }
 

--- a/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/action/ReceiverSupplyScenarioParametersAndStateSetupAction.java
+++ b/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/action/ReceiverSupplyScenarioParametersAndStateSetupAction.java
@@ -47,6 +47,7 @@ public class ReceiverSupplyScenarioParametersAndStateSetupAction extends PintAct
   public void handlePartyInput(JsonNode partyInput) {
     super.handlePartyInput(partyInput);
     var rsp = ReceiverScenarioParameters.fromJson(partyInput.path("input"));
+    rsp.validate();
     this.setRsp(rsp);
   }
 

--- a/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/action/SenderSupplyScenarioParametersAction.java
+++ b/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/action/SenderSupplyScenarioParametersAction.java
@@ -35,6 +35,7 @@ public class SenderSupplyScenarioParametersAction extends PintAction {
   public void handlePartyInput(JsonNode partyInput) {
     super.handlePartyInput(partyInput);
     var ssp = SenderScenarioParameters.fromJson(partyInput.path("input"));
+    ssp.validate();
     this.setSsp(ssp);
     this.setDsp(this.getDsp().withDocumentCount(this.documentCount));
   }

--- a/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/models/ReceiverScenarioParameters.java
+++ b/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/models/ReceiverScenarioParameters.java
@@ -9,7 +9,7 @@ import org.dcsa.conformance.core.party.ScenarioParameters;
 
 @With
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record ReceiverScenarioParameters(JsonNode receiverParty, String receiverPublicKeyPEM)
+public record ReceiverScenarioParameters(JsonNode receiverParty, String receiversX509SigningCertificateInPEMFormat)
     implements ScenarioParameters {
 
   public static ReceiverScenarioParameters fromJson(JsonNode jsonNode) {

--- a/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/models/ReceiverScenarioParameters.java
+++ b/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/models/ReceiverScenarioParameters.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.With;
 import org.dcsa.conformance.core.party.ScenarioParameters;
+import org.dcsa.conformance.standards.ebl.crypto.PayloadSignerFactory;
 
 @With
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -14,5 +15,13 @@ public record ReceiverScenarioParameters(JsonNode receiverParty, String receiver
 
   public static ReceiverScenarioParameters fromJson(JsonNode jsonNode) {
     return OBJECT_MAPPER.convertValue(jsonNode, ReceiverScenarioParameters.class);
+  }
+
+
+  public void validate() {
+    PayloadSignerFactory.verifierFromPemEncodedCertificate(
+      receiversX509SigningCertificateInPEMFormat,
+      "receiversX509SigningCertificateInPEMFormat"
+    );
   }
 }

--- a/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/models/SenderScenarioParameters.java
+++ b/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/models/SenderScenarioParameters.java
@@ -5,6 +5,7 @@ import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.With;
 import org.dcsa.conformance.core.party.ScenarioParameters;
+import org.dcsa.conformance.standards.ebl.crypto.PayloadSignerFactory;
 
 @With
 public record SenderScenarioParameters(
@@ -16,5 +17,16 @@ public record SenderScenarioParameters(
 
   public static SenderScenarioParameters fromJson(JsonNode jsonNode) {
     return OBJECT_MAPPER.convertValue(jsonNode, SenderScenarioParameters.class);
+  }
+
+  public void validate() {
+    PayloadSignerFactory.verifierFromPemEncodedCertificate(
+      carriersX509SigningCertificateInPEMFormat,
+      "carriersX509SigningCertificateInPEMFormat"
+    );
+    PayloadSignerFactory.verifierFromPemEncodedCertificate(
+      sendersX509SigningCertificateInPEMFormat,
+      "sendersX509SigningCertificateInPEMFormat"
+    );
   }
 }

--- a/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/models/SenderScenarioParameters.java
+++ b/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/models/SenderScenarioParameters.java
@@ -10,8 +10,8 @@ import org.dcsa.conformance.core.party.ScenarioParameters;
 public record SenderScenarioParameters(
     String transportDocumentReference,
     String eblPlatform,
-    String senderPublicKeyPEM,
-    String carrierPublicKeyPEM)
+    String sendersX509SigningCertificateInPEMFormat,
+    String carriersX509SigningCertificateInPEMFormat)
     implements ScenarioParameters {
 
   public static SenderScenarioParameters fromJson(JsonNode jsonNode) {

--- a/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/models/TDReceiveState.java
+++ b/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/models/TDReceiveState.java
@@ -285,7 +285,7 @@ public class TDReceiveState {
 
   public SignatureVerifier getSignatureVerifierForSenderSignatures() {
     var pem = state.path(EXPECTED_PUBLIC_KEY).asText();
-    return PayloadSignerFactory.verifierFromPemEncodedPublicKey(pem);
+    return PayloadSignerFactory.verifierFromPemEncodedCertificate(pem, EXPECTED_PUBLIC_KEY);
   }
 
   public static TDReceiveState fromPersistentStore(JsonNode state) {

--- a/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/party/PintReceivingPlatform.java
+++ b/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/party/PintReceivingPlatform.java
@@ -97,7 +97,7 @@ public class PintReceivingPlatform extends ConformanceParty {
     var tdr = ssp.transportDocumentReference();
     var scenarioClass = ScenarioClass.valueOf(actionPrompt.required("scenarioClass").asText());
     var receivingParameters = getReceiverScenarioParameters(ssp.eblPlatform(), scenarioClass);
-    var tdState = TDReceiveState.newInstance(tdr, ssp.senderPublicKeyPEM(), receivingParameters);
+    var tdState = TDReceiveState.newInstance(tdr, ssp.sendersX509SigningCertificateInPEMFormat(), receivingParameters);
     tdState.setExpectedReceiver(
       generateReceiverParty(
         ssp.eblPlatform(),


### PR DESCRIPTION
- Rename some properties to clarify they are PEM encoded X.509 certs
- Improve the error handling (name the attribute that fails, an additional error check, tweak an error message)
- Eagerly validate the X.509 PEM certificate in the input method to match a similar change to EBL_ISS made by George recently.

These changes are all related to or part of SD-1940.

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Transitioned from public key PEM to X.509 certificate PEM handling.

- Improved error messages for certificate validation failures.

- Added validation methods for scenario parameters in PINT.

- Updated human-readable prompts for better clarity in PINT actions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>CarrierScenarioParametersAction.java</strong><dd><code>Updated to use X.509 certificate for carrier signing.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/254/files#diff-c97b74fcbd65b003adb85af0ede2b5a0a46eea2890b85351367478a39aceae8f">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>IssuanceRequestResponseAction.java</strong><dd><code>Switched to X.509 certificate for signature verification.</code></dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/254/files#diff-565ba65bdf210374dc388009cdf73b5259cecb6aa3aa0b1849c912bbda8783f4">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CarrierScenarioParameters.java</strong><dd><code>Renamed attribute to reflect X.509 certificate usage.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/254/files#diff-78330d1cc2b5d91727132ec2f837416b96e10bdbebc011353a7035996e28b1b1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PintAction.java</strong><dd><code>Updated to use X.509 certificates for signature verification.</code></dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/254/files#diff-456ff3774ff78b881d421c3a9f4db6bde3d5df27988e4e69498e5dde2c4dcaec">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ReceiverSupplyScenarioParametersAndStateSetupAction.java</strong><dd><code>Added validation and updated prompt for receiver setup.</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/254/files#diff-7892bdbeaa6b77cac8faf745b0bb13b19a7f69e2d0470c616f98026e658b9dca">+10/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SenderSupplyScenarioParametersAction.java</strong><dd><code>Added validation and updated prompt for sender setup.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/254/files#diff-9bd76e060d95807a6a9449a73fe74845950e923d3e6df8f63eb5f3bf4470f23b">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ReceiverScenarioParameters.java</strong><dd><code>Added validation for receiver's X.509 certificate.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/254/files#diff-abf88e402a74f081be4a5206a0c9d658f32a30b2d155951a1dbb0f4e7f412213">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SenderScenarioParameters.java</strong><dd><code>Added validation for sender and carrier X.509 certificates.</code></dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/254/files#diff-b723ef63bb202bd1dd56f648f9cde6d63688fd6bca3d92145b826e407e1e87c5">+14/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TDReceiveState.java</strong><dd><code>Updated to use X.509 certificate for sender signature verification.</code></dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/254/files#diff-bae0d949c819543c91cc61114e28897271a381baee46f913336f057316956ce4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PintReceivingPlatform.java</strong><dd><code>Transitioned to X.509 certificate for sender verification.</code></dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/254/files#diff-271bf1afb4df55d99751523a909c03ae46229fb6b4f93c48c719b7b401a10724">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>PayloadSignerFactory.java</strong><dd><code>Enhanced certificate parsing and error handling.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/254/files#diff-840712e24423bf01b51a9feafd596de117537eb171181d3395e5b16179fe794f">+10/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ManualTestBase.java</strong><dd><code>Updated test prompts to align with new PINT prompts.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/254/files#diff-73f51d85ef8d371a643b08949f37b6b4d9644e82b45f009208a705608d44c1b0">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information