### PR TITLE
Rename internal attribute to make it less confusing

### DIFF
--- a/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/models/TDReceiveState.java
+++ b/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/models/TDReceiveState.java
@@ -35,7 +35,7 @@ public class TDReceiveState {
   private static final String SCENARIO_CLASS = "scenarioClass";
   private static final String ENVELOPE_REFERENCE = "envelopeReference";
 
-  private static final String EXPECTED_PUBLIC_KEY = "expectedSenderPublicKey";
+  private static final String EXPECTED_SIGNING_CERT_ATTR = "expectedSenderX509Certificate";
 
   private static final String TRANSFER_CHAIN_ENTRY_HISTORY = "transferChainEntryHistory";
 
@@ -284,8 +284,8 @@ public class TDReceiveState {
   }
 
   public SignatureVerifier getSignatureVerifierForSenderSignatures() {
-    var pem = state.path(EXPECTED_PUBLIC_KEY).asText();
-    return PayloadSignerFactory.verifierFromPemEncodedCertificate(pem, EXPECTED_PUBLIC_KEY);
+    var pem = state.path(EXPECTED_SIGNING_CERT_ATTR).asText();
+    return PayloadSignerFactory.verifierFromPemEncodedCertificate(pem, EXPECTED_SIGNING_CERT_ATTR);
   }
 
   public static TDReceiveState fromPersistentStore(JsonNode state) {
@@ -296,7 +296,7 @@ public class TDReceiveState {
     var state = OBJECT_MAPPER.createObjectNode()
       .put(TRANSPORT_DOCUMENT_REFERENCE, transportDocumentReference)
       .put(TRANSFER_STATE, TransferState.NOT_STARTED.name())
-      .put(EXPECTED_PUBLIC_KEY, senderPublicKeyPEM);
+      .put(EXPECTED_SIGNING_CERT_ATTR, senderPublicKeyPEM);
     return new TDReceiveState(state);
   }
 


### PR DESCRIPTION
### **User description**
The variable should have been renamed as a part of the "Public key" -> "Cert" changes, but was overlooked until a review comment in a recent PR.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Renamed internal attribute for clarity and consistency.

- Updated references to the renamed attribute across methods.

- Improved alignment with "Public key" to "Cert" terminology changes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TDReceiveState.java</strong><dd><code>Rename and update internal attribute references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pint/src/main/java/org/dcsa/conformance/standards/eblinterop/models/TDReceiveState.java

<li>Renamed <code>EXPECTED_PUBLIC_KEY</code> to <code>EXPECTED_SIGNING_CERT_ATTR</code>.<br> <li> Updated method <code>getSignatureVerifierForSenderSignatures</code> to use the new <br>attribute.<br> <li> Adjusted <code>newInstance</code> method to reflect the renamed attribute.<br> <li> Improved consistency with terminology changes in the codebase.


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/260/files#diff-bae0d949c819543c91cc61114e28897271a381baee46f913336f057316956ce4">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information