### PR TITLE
SD-1963: Use the RFC8785 approved Java library for JSON canonicalization

### DIFF
--- a/ebl-issuance/pom.xml
+++ b/ebl-issuance/pom.xml
@@ -22,10 +22,5 @@
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>io.setl</groupId>
-			<artifactId>canonical-json</artifactId>
-			<version>3.0</version>
-		</dependency>
 	</dependencies>
 </project>

--- a/ebl/pom.xml
+++ b/ebl/pom.xml
@@ -29,9 +29,9 @@
 			<version>10.0.1</version>
 		</dependency>
 		<dependency>
-			<groupId>io.setl</groupId>
-			<artifactId>canonical-json</artifactId>
-			<version>3.0</version>
+			<groupId>io.github.erdtman</groupId>
+			<artifactId>java-json-canonicalization</artifactId>
+			<version>1.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/Checksums.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/Checksums.java
@@ -1,9 +1,8 @@
 package org.dcsa.conformance.standards.ebl.crypto;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.setl.json.Canonical;
-import io.setl.json.jackson.Convert;
 import lombok.SneakyThrows;
+import org.erdtman.jcs.JsonCanonicalizer;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -13,7 +12,7 @@ public class Checksums {
 
   @SneakyThrows
   public static String sha256CanonicalJson(JsonNode node) {
-    return sha256(((Canonical) Convert.toJson(node)).toCanonicalString());
+    return sha256(new JsonCanonicalizer(node.toString()).getEncodedString());
   }
 
   @SneakyThrows


### PR DESCRIPTION
### **User description**
We received a report in products that a supporting tool were not producing the correct checksums for TDs. Turns out that the library we were using (same as in Conformance Framework) does not produce the same checksum as the Java library listed RFC8785. This commit changes the library to use the one used in RFC8785 to avoid future cases of mismatches.


@gj0dcsa: This might affect HMMs issuance tests.

___

### **PR Type**
Enhancement


___

### **Description**
- Replaced JSON canonicalization library with RFC8785-approved library.

- Updated checksum computation to use the new library.

- Removed dependency on `io.setl.canonical-json` library.

- Added dependency on `io.github.erdtman.java-json-canonicalization` library.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Checksums.java</strong><dd><code>Update checksum computation with new canonicalization library</code></dd></summary>
<hr>

ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/Checksums.java

<li>Replaced <code>io.setl.json</code> library with <code>org.erdtman.jcs</code>.<br> <li> Updated checksum computation to use <code>JsonCanonicalizer</code>.


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/261/files#diff-ed6cc553bdae58f73019814987a16ac6d64210a8649b883299f9574612992651">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Remove outdated JSON canonicalization library dependency</code>&nbsp; </dd></summary>
<hr>

ebl-issuance/pom.xml

- Removed dependency on `io.setl.canonical-json` library.


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/261/files#diff-82b3365483ba038c2c2f969a0049d068221b9ab3a4291efcadfd49dc9f99aeda">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Update JSON canonicalization library dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl/pom.xml

<li>Replaced <code>io.setl.canonical-json</code> dependency with <br><code>io.github.erdtman.java-json-canonicalization</code>.


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/261/files#diff-b6c9c90f1fe631f6e270a83622058a151fd75f121ded23fd8436688cd37ec4cd">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information