### PR TITLE
Update Java dependencies

### DIFF
--- a/cdk/pom.xml
+++ b/cdk/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>software.amazon.awscdk</groupId>
 			<artifactId>aws-cdk-lib</artifactId>
-			<version>2.174.1</version>
+			<version>2.177.0</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,7 +37,6 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>5.15.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -14,12 +14,13 @@
 		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<spring.boot.version>3.4.1</spring.boot.version>
+		<spring.boot.version>3.4.2</spring.boot.version>
 		<jackson.version>2.18.2</jackson.version>
 		<lombok.version>1.18.36</lombok.version>
 		<log4j.version>2.24.3</log4j.version>
 		<slf4j.version>2.0.16</slf4j.version>
 		<junit.version>5.11.4</junit.version>
+		<mockito.version>5.15.2</mockito.version>
 
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<sonar.organization>dcsaorg</sonar.organization>
@@ -174,6 +175,12 @@
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter-engine</artifactId>
 				<version>${junit.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-core</artifactId>
+				<version>${mockito.version}</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>

--- a/sandbox/pom.xml
+++ b/sandbox/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>dynamodb</artifactId>
-			<version>2.29.48</version>
+			<version>2.30.7</version>
 		</dependency>
 		<!-- Test scoped dependencies -->
 		<dependency>
@@ -77,7 +77,6 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>5.14.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>4.27.0</version>
+			<version>4.28.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
* Move Mockito version to dependencyManagement

Note: I did try to update WebUI libraries, because of moderate sec issue, but failed. I needed to update Angular, which I tried and worked, but even with the latest version, the dependency with issues (vite) is still vulnerable. I need to try later again, when hopefully Angular used the right version as well. It also needs Angular to go from 16 -> 19, so it needs more testing & checks. 