### PR TITLE
SD-1895 Add JIT 2.0 GET actions

### DIFF
--- a/core/src/main/java/org/dcsa/conformance/core/party/ConformanceParty.java
+++ b/core/src/main/java/org/dcsa/conformance/core/party/ConformanceParty.java
@@ -100,7 +100,7 @@ public abstract class ConformanceParty implements StatefulEntity {
 
   protected abstract void importPartyJsonState(ObjectNode sourceObjectNode);
 
-  protected void addOperatorLogEntry(String logEntry) {
+  public void addOperatorLogEntry(String logEntry) {
     operatorLog.addFirst(logEntry);
     if (operatorLog.size() > MAX_OPERATOR_LOG_RECORDS - 1) {
       operatorLog.removeLast();

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/JitScenarioListBuilder.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/JitScenarioListBuilder.java
@@ -832,7 +832,7 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
 
     scenarioList.put(
         "3. PC-TC-S-V-A-ERP-A Provider answering GET calls",
-        supplyScenarioParameters(context, ANY)
+        supplyScenarioParameters(context, FULL_ERP)
             .thenEither(
                 sendPC_TC_SC_VS(
                     context,
@@ -842,6 +842,97 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
                         context,
                         sendTimestamp(context, ACTUAL)
                             .then(getTimestampActions(context, false))))));
+
+    scenarioList.put(
+        "4. PC-TC-S-V-A-ERP-A Consumer answering GET calls",
+        supplyScenarioParameters(context, FULL_ERP)
+            .thenEither(
+                sendPC_TC_SC_VS(
+                    context,
+                    null,
+                    S_A_PATTERN,
+                    sendERPTimestamps(
+                        context,
+                        sendTimestamp(context, ACTUAL).then(getTimestampActions(context, true))))));
+
+    scenarioList.put(
+        "5. PC-TC-S-V-A Provider answering GET calls",
+        supplyScenarioParameters(context, S_A_PATTERN)
+            .thenEither(
+                sendPC_TC_SC_VS(
+                    context,
+                    null,
+                    S_A_PATTERN,
+                    sendTimestamp(context, ACTUAL)
+                        .then(
+                            getAction(
+                                    context,
+                                    JitGetType.TIMESTAMPS,
+                                    JitGetTimestampCallFilters.props().get(3),
+                                    false)
+                                .then(
+                                    getAction(
+                                            context,
+                                            JitGetType.TIMESTAMPS,
+                                            JitGetTimestampCallFilters.props().get(4),
+                                            false)
+                                        .then(
+                                            getAction(
+                                                context,
+                                                JitGetType.TIMESTAMPS,
+                                                List.of(
+                                                    JitGetTimestampCallFilters.props().get(4),
+                                                    JitGetTimestampCallFilters.props().get(5)),
+                                                false)))))));
+    scenarioList.put(
+        "6. PC-TC-S-V-A Consumer answering GET calls",
+        supplyScenarioParameters(context, S_A_PATTERN)
+            .thenEither(
+                sendPC_TC_SC_VS(
+                    context,
+                    null,
+                    S_A_PATTERN,
+                    sendTimestamp(context, ACTUAL)
+                        .then(
+                            getAction(
+                                    context,
+                                    JitGetType.TIMESTAMPS,
+                                    JitGetTimestampCallFilters.props().get(3),
+                                    true)
+                                .then(
+                                    getAction(
+                                            context,
+                                            JitGetType.TIMESTAMPS,
+                                            JitGetTimestampCallFilters.props().get(4),
+                                            true)
+                                        .then(
+                                            getAction(
+                                                context,
+                                                JitGetType.TIMESTAMPS,
+                                                List.of(
+                                                    JitGetTimestampCallFilters.props().get(4),
+                                                    JitGetTimestampCallFilters.props().get(5)),
+                                                true)))))));
+    scenarioList.put(
+        "7. Moves service type Provider answering GET calls",
+        supplyScenarioParameters(context, GIVEN)
+            .thenEither(
+                portCall(context)
+                    .then(
+                        terminalCall(context)
+                            .then(
+                                serviceCall(context, MOVES, GIVEN)
+                                    .then(getServiceCallActions(context, false))))));
+    scenarioList.put(
+        "8. Moves service type Consumer answering GET calls",
+        supplyScenarioParameters(context, GIVEN)
+            .thenEither(
+                portCall(context)
+                    .then(
+                        terminalCall(context)
+                            .then(
+                                serviceCall(context, MOVES, GIVEN)
+                                    .then(getServiceCallActions(context, true))))));
   }
 
   private static JitScenarioListBuilder getTimestampActions(

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/JitScenarioListBuilder.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/JitScenarioListBuilder.java
@@ -183,8 +183,6 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
   private static void addScenarioGroup4(
       LinkedHashMap<String, JitScenarioListBuilder> scenarioList, JitScenarioContext context) {
 
-    // TODO: Not sure, to add this one: PC - TC - S - V - E - R - P - P - A
-
     scenarioList.put(
         "4. PC-TC-S-V-ERP-A in-band ERP variations",
         supplyScenarioParameters(context, FULL_ERP)
@@ -934,8 +932,7 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
       JitScenarioContext context, JitTimestampType timestampType) {
     if (timestampType == REQUESTED) {
       return new JitScenarioListBuilder(
-          previousAction ->
-              new JitOOBTimestampInputAction(context, previousAction, timestampType));
+          previousAction -> new JitOOBTimestampInputAction(context, previousAction, timestampType));
     }
     return new JitScenarioListBuilder(
         previousAction -> new JitOOBTimestampAction(context, previousAction, timestampType, true));

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/JitScenarioListBuilder.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/JitScenarioListBuilder.java
@@ -25,6 +25,7 @@ import org.dcsa.conformance.standards.jit.action.JitTerminalCallAction;
 import org.dcsa.conformance.standards.jit.action.JitTimestampAction;
 import org.dcsa.conformance.standards.jit.action.JitVesselStatusAction;
 import org.dcsa.conformance.standards.jit.action.SupplyScenarioParametersAction;
+import org.dcsa.conformance.standards.jit.checks.JitChecks;
 import org.dcsa.conformance.standards.jit.model.JitGetPortCallFilters;
 import org.dcsa.conformance.standards.jit.model.JitGetPortServiceCallFilters;
 import org.dcsa.conformance.standards.jit.model.JitGetTerminalCallFilters;
@@ -795,7 +796,16 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
                         terminalCall(context)
                             .then(
                                 serviceCall(context, null, ANY)
-                                    .then(getServiceCallActions(context, false))))));
+                                    .then(getServiceCallActions(context, false)))),
+                sendPC_TC_SC_VS(
+                    context,
+                    null,
+                    ANY,
+                    getAction(
+                        context,
+                        JitGetType.VESSEL_STATUSES,
+                        JitChecks.PORT_CALL_SERVICE_ID,
+                        false))));
     scenarioList.put(
         "2. PC-TC-S-V Consumer answering GET calls",
         supplyScenarioParameters(context, ANY)
@@ -808,7 +818,16 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
                         terminalCall(context)
                             .then(
                                 serviceCall(context, null, ANY)
-                                    .then(getServiceCallActions(context, true))))));
+                                    .then(getServiceCallActions(context, true)))),
+                sendPC_TC_SC_VS(
+                    context,
+                    null,
+                    ANY,
+                    getAction(
+                        context,
+                        JitGetType.VESSEL_STATUSES,
+                        JitChecks.PORT_CALL_SERVICE_ID,
+                        true))));
   }
 
   private static JitScenarioListBuilder getPortCallActions(

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/JitScenarioListBuilder.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/JitScenarioListBuilder.java
@@ -26,6 +26,7 @@ import org.dcsa.conformance.standards.jit.action.JitTimestampAction;
 import org.dcsa.conformance.standards.jit.action.JitVesselStatusAction;
 import org.dcsa.conformance.standards.jit.action.SupplyScenarioParametersAction;
 import org.dcsa.conformance.standards.jit.model.JitGetPortCallFilters;
+import org.dcsa.conformance.standards.jit.model.JitGetTerminalCallFilters;
 import org.dcsa.conformance.standards.jit.model.JitGetType;
 import org.dcsa.conformance.standards.jit.model.JitServiceTypeSelector;
 import org.dcsa.conformance.standards.jit.model.JitTimestampType;
@@ -783,102 +784,144 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
       LinkedHashMap<String, JitScenarioListBuilder> scenarioList, JitScenarioContext context) {
     scenarioList.put(
         "1. PC-TC-S-V Provider answering GET calls",
-        supplyScenarioParameters(context, FULL_ERP)
+        supplyScenarioParameters(context, ANY)
             .thenEither(
+                portCall(context).then(getPortCallActions(context, false)),
                 portCall(context)
-                    .then(
-                        getAction(
-                                context,
-                                JitGetType.PORT_CALLS,
-                                Collections.singletonList(JitGetPortCallFilters.props().getFirst()),
-                                false)
-                            .then(
-                                getAction(
-                                        context,
-                                        JitGetType.PORT_CALLS,
-                                        Collections.singletonList(
-                                            JitGetPortCallFilters.props().get(1)),
-                                        false)
-                                    .then(
-                                        getAction(
-                                                context,
-                                                JitGetType.PORT_CALLS,
-                                                Collections.singletonList(
-                                                    JitGetPortCallFilters.props().get(2)),
-                                                false)
-                                            .then(
-                                                getAction(
-                                                        context,
-                                                        JitGetType.PORT_CALLS,
-                                                        Collections.singletonList(
-                                                            JitGetPortCallFilters.props().get(3)),
-                                                        false)
-                                                    .then(
-                                                        getAction(
-                                                                context,
-                                                                JitGetType.PORT_CALLS,
-                                                                Collections.singletonList(
-                                                                    JitGetPortCallFilters.props()
-                                                                        .get(4)),
-                                                                false)
-                                                            .then(
-                                                                getAction(
-                                                                    context,
-                                                                    JitGetType.PORT_CALLS,
-                                                                    Collections.singletonList(
-                                                                        JitGetPortCallFilters
-                                                                            .props()
-                                                                            .get(5)),
-                                                                    false)))))))));
+                    .then(terminalCall(context).then(getTerminalCallActions(context, false)))));
     scenarioList.put(
         "2. PC-TC-S-V Consumer answering GET calls",
-        supplyScenarioParameters(context, FULL_ERP)
+        supplyScenarioParameters(context, ANY)
             .thenEither(
+                portCall(context).then(getPortCallActions(context, true)),
                 portCall(context)
-                    .then(
-                        getAction(
-                                context,
-                                JitGetType.PORT_CALLS,
-                                Collections.singletonList(JitGetPortCallFilters.props().getFirst()),
-                                true)
-                            .then(
-                                getAction(
-                                        context,
-                                        JitGetType.PORT_CALLS,
-                                        Collections.singletonList(
-                                            JitGetPortCallFilters.props().get(1)),
-                                        true)
-                                    .then(
-                                        getAction(
+                    .then(terminalCall(context).then(getTerminalCallActions(context, true)))));
+  }
+
+  private static JitScenarioListBuilder getPortCallActions(
+      JitScenarioContext context, boolean requestedByProvider) {
+    return getAction(
+            context,
+            JitGetType.PORT_CALLS,
+            JitGetPortCallFilters.props().getFirst(),
+            requestedByProvider)
+        .then(
+            getAction(
+                    context,
+                    JitGetType.PORT_CALLS,
+                    JitGetPortCallFilters.props().get(1),
+                    requestedByProvider)
+                .then(
+                    getAction(
+                            context,
+                            JitGetType.PORT_CALLS,
+                            JitGetPortCallFilters.props().get(2),
+                            requestedByProvider)
+                        .then(
+                            getAction(
+                                    context,
+                                    JitGetType.PORT_CALLS,
+                                    JitGetPortCallFilters.props().get(3),
+                                    requestedByProvider)
+                                .then(
+                                    getAction(
+                                            context,
+                                            JitGetType.PORT_CALLS,
+                                            JitGetPortCallFilters.props().get(4),
+                                            requestedByProvider)
+                                        .then(
+                                            getAction(
                                                 context,
                                                 JitGetType.PORT_CALLS,
-                                                Collections.singletonList(
-                                                    JitGetPortCallFilters.props().get(2)),
-                                                true)
-                                            .then(
-                                                getAction(
-                                                        context,
-                                                        JitGetType.PORT_CALLS,
-                                                        Collections.singletonList(
-                                                            JitGetPortCallFilters.props().get(3)),
-                                                        true)
-                                                    .then(
-                                                        getAction(
-                                                                context,
-                                                                JitGetType.PORT_CALLS,
-                                                                Collections.singletonList(
-                                                                    JitGetPortCallFilters.props()
-                                                                        .get(4)),
-                                                                true)
-                                                            .then(
-                                                                getAction(
+                                                JitGetPortCallFilters.props().get(5),
+                                                requestedByProvider))))));
+  }
+
+  private static JitScenarioListBuilder getTerminalCallActions(
+      JitScenarioContext context, boolean requestedByProvider) {
+    return getAction(
+            context,
+            JitGetType.TERMINAL_CALLS,
+            JitGetTerminalCallFilters.props().getFirst(),
+            requestedByProvider)
+        .then(
+            getAction(
+                    context,
+                    JitGetType.TERMINAL_CALLS,
+                    JitGetTerminalCallFilters.props().get(1),
+                    requestedByProvider)
+                .then(
+                    getAction(
+                            context,
+                            JitGetType.TERMINAL_CALLS,
+                            JitGetTerminalCallFilters.props().get(2),
+                            requestedByProvider)
+                        .then(
+                            getAction(
+                                    context,
+                                    JitGetType.TERMINAL_CALLS,
+                                    JitGetTerminalCallFilters.props().get(3),
+                                    requestedByProvider)
+                                .then(
+                                    getAction(
+                                            context,
+                                            JitGetType.TERMINAL_CALLS,
+                                            JitGetTerminalCallFilters.props().get(4),
+                                            requestedByProvider)
+                                        .then(
+                                            getAction(
+                                                    context,
+                                                    JitGetType.TERMINAL_CALLS,
+                                                    JitGetTerminalCallFilters.props().get(5),
+                                                    requestedByProvider)
+                                                .then(
+                                                    getAction(
+                                                            context,
+                                                            JitGetType.TERMINAL_CALLS,
+                                                            List.of(
+                                                                JitGetTerminalCallFilters.props()
+                                                                    .get(2),
+                                                                JitGetTerminalCallFilters.props()
+                                                                    .get(6)),
+                                                            requestedByProvider)
+                                                        .then(
+                                                            getAction(
                                                                     context,
-                                                                    JitGetType.PORT_CALLS,
-                                                                    Collections.singletonList(
-                                                                        JitGetPortCallFilters
+                                                                    JitGetType.TERMINAL_CALLS,
+                                                                    List.of(
+                                                                        JitGetTerminalCallFilters
                                                                             .props()
-                                                                            .get(5)),
-                                                                    true)))))))));
+                                                                            .get(2),
+                                                                        JitGetTerminalCallFilters
+                                                                            .props()
+                                                                            .get(7)),
+                                                                    requestedByProvider)
+                                                                .then(
+                                                                    getAction(
+                                                                            context,
+                                                                            JitGetType
+                                                                                .TERMINAL_CALLS,
+                                                                            List.of(
+                                                                                JitGetTerminalCallFilters
+                                                                                    .props()
+                                                                                    .get(3),
+                                                                                JitGetTerminalCallFilters
+                                                                                    .props()
+                                                                                    .get(8)),
+                                                                            requestedByProvider)
+                                                                        .then(
+                                                                            getAction(
+                                                                                context,
+                                                                                JitGetType
+                                                                                    .TERMINAL_CALLS,
+                                                                                List.of(
+                                                                                    JitGetTerminalCallFilters
+                                                                                        .props()
+                                                                                        .get(4),
+                                                                                    JitGetTerminalCallFilters
+                                                                                        .props()
+                                                                                        .get(9)),
+                                                                                requestedByProvider))))))))));
   }
 
   private static void addScenarioGroupSecondary1(
@@ -1134,6 +1177,18 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
                 .then(
                     serviceCall(context, serviceType, selector)
                         .then(vesselStatus(context).thenEither(thenEither))));
+  }
+
+  private static JitScenarioListBuilder getAction(
+      JitScenarioContext context, JitGetType type, String filter, boolean requestedByProvider) {
+    return new JitScenarioListBuilder(
+        previousAction ->
+            new JitGetAction(
+                context,
+                previousAction,
+                type,
+                Collections.singletonList(filter),
+                requestedByProvider));
   }
 
   private static JitScenarioListBuilder getAction(

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/JitScenarioListBuilder.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/JitScenarioListBuilder.java
@@ -4,7 +4,9 @@ import static org.dcsa.conformance.standards.jit.model.JitServiceTypeSelector.*;
 import static org.dcsa.conformance.standards.jit.model.JitTimestampType.*;
 import static org.dcsa.conformance.standards.jit.model.PortCallServiceType.*;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.function.Function;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +14,7 @@ import org.dcsa.conformance.core.scenario.ConformanceAction;
 import org.dcsa.conformance.core.scenario.ScenarioListBuilder;
 import org.dcsa.conformance.standards.jit.action.JitCancelAction;
 import org.dcsa.conformance.standards.jit.action.JitDeclineAction;
+import org.dcsa.conformance.standards.jit.action.JitGetAction;
 import org.dcsa.conformance.standards.jit.action.JitOOBTimestampAction;
 import org.dcsa.conformance.standards.jit.action.JitOOBTimestampInputAction;
 import org.dcsa.conformance.standards.jit.action.JitOmitPortCallAction;
@@ -22,6 +25,8 @@ import org.dcsa.conformance.standards.jit.action.JitTerminalCallAction;
 import org.dcsa.conformance.standards.jit.action.JitTimestampAction;
 import org.dcsa.conformance.standards.jit.action.JitVesselStatusAction;
 import org.dcsa.conformance.standards.jit.action.SupplyScenarioParametersAction;
+import org.dcsa.conformance.standards.jit.model.JitGetPortCallFilters;
+import org.dcsa.conformance.standards.jit.model.JitGetType;
 import org.dcsa.conformance.standards.jit.model.JitServiceTypeSelector;
 import org.dcsa.conformance.standards.jit.model.JitTimestampType;
 import org.dcsa.conformance.standards.jit.model.PortCallServiceType;
@@ -74,6 +79,9 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
     addScenarioGroup10(scenarioList, context);
     addScenarioGroup11(scenarioList, context);
     addScenarioGroup12(scenarioList, context);
+
+    // Scenario suite: "GET endpoint conformance"
+    addScenarioGroupGET1(scenarioList, context);
 
     // Scenario suite: "Secondary sender and receiver conformance"
     addScenarioGroupSecondary1(scenarioList, context);
@@ -771,6 +779,108 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
                                 serviceCall(context, null, FULL_ERP).then(declineCall(context))))));
   }
 
+  private static void addScenarioGroupGET1(
+      LinkedHashMap<String, JitScenarioListBuilder> scenarioList, JitScenarioContext context) {
+    scenarioList.put(
+        "1. PC-TC-S-V Provider answering GET calls",
+        supplyScenarioParameters(context, FULL_ERP)
+            .thenEither(
+                portCall(context)
+                    .then(
+                        getAction(
+                                context,
+                                JitGetType.PORT_CALLS,
+                                Collections.singletonList(JitGetPortCallFilters.props().getFirst()),
+                                false)
+                            .then(
+                                getAction(
+                                        context,
+                                        JitGetType.PORT_CALLS,
+                                        Collections.singletonList(
+                                            JitGetPortCallFilters.props().get(1)),
+                                        false)
+                                    .then(
+                                        getAction(
+                                                context,
+                                                JitGetType.PORT_CALLS,
+                                                Collections.singletonList(
+                                                    JitGetPortCallFilters.props().get(2)),
+                                                false)
+                                            .then(
+                                                getAction(
+                                                        context,
+                                                        JitGetType.PORT_CALLS,
+                                                        Collections.singletonList(
+                                                            JitGetPortCallFilters.props().get(3)),
+                                                        false)
+                                                    .then(
+                                                        getAction(
+                                                                context,
+                                                                JitGetType.PORT_CALLS,
+                                                                Collections.singletonList(
+                                                                    JitGetPortCallFilters.props()
+                                                                        .get(4)),
+                                                                false)
+                                                            .then(
+                                                                getAction(
+                                                                    context,
+                                                                    JitGetType.PORT_CALLS,
+                                                                    Collections.singletonList(
+                                                                        JitGetPortCallFilters
+                                                                            .props()
+                                                                            .get(5)),
+                                                                    false)))))))));
+    scenarioList.put(
+        "2. PC-TC-S-V Consumer answering GET calls",
+        supplyScenarioParameters(context, FULL_ERP)
+            .thenEither(
+                portCall(context)
+                    .then(
+                        getAction(
+                                context,
+                                JitGetType.PORT_CALLS,
+                                Collections.singletonList(JitGetPortCallFilters.props().getFirst()),
+                                true)
+                            .then(
+                                getAction(
+                                        context,
+                                        JitGetType.PORT_CALLS,
+                                        Collections.singletonList(
+                                            JitGetPortCallFilters.props().get(1)),
+                                        true)
+                                    .then(
+                                        getAction(
+                                                context,
+                                                JitGetType.PORT_CALLS,
+                                                Collections.singletonList(
+                                                    JitGetPortCallFilters.props().get(2)),
+                                                true)
+                                            .then(
+                                                getAction(
+                                                        context,
+                                                        JitGetType.PORT_CALLS,
+                                                        Collections.singletonList(
+                                                            JitGetPortCallFilters.props().get(3)),
+                                                        true)
+                                                    .then(
+                                                        getAction(
+                                                                context,
+                                                                JitGetType.PORT_CALLS,
+                                                                Collections.singletonList(
+                                                                    JitGetPortCallFilters.props()
+                                                                        .get(4)),
+                                                                true)
+                                                            .then(
+                                                                getAction(
+                                                                    context,
+                                                                    JitGetType.PORT_CALLS,
+                                                                    Collections.singletonList(
+                                                                        JitGetPortCallFilters
+                                                                            .props()
+                                                                            .get(5)),
+                                                                    true)))))))));
+  }
+
   private static void addScenarioGroupSecondary1(
       LinkedHashMap<String, JitScenarioListBuilder> scenarioList, JitScenarioContext context) {
     scenarioList.put(
@@ -1024,5 +1134,15 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
                 .then(
                     serviceCall(context, serviceType, selector)
                         .then(vesselStatus(context).thenEither(thenEither))));
+  }
+
+  private static JitScenarioListBuilder getAction(
+      JitScenarioContext context,
+      JitGetType type,
+      List<String> filters,
+      boolean requestedByProvider) {
+    return new JitScenarioListBuilder(
+        previousAction ->
+            new JitGetAction(context, previousAction, type, filters, requestedByProvider));
   }
 }

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/JitScenarioListBuilder.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/JitScenarioListBuilder.java
@@ -26,6 +26,7 @@ import org.dcsa.conformance.standards.jit.action.JitTimestampAction;
 import org.dcsa.conformance.standards.jit.action.JitVesselStatusAction;
 import org.dcsa.conformance.standards.jit.action.SupplyScenarioParametersAction;
 import org.dcsa.conformance.standards.jit.model.JitGetPortCallFilters;
+import org.dcsa.conformance.standards.jit.model.JitGetPortServiceCallFilters;
 import org.dcsa.conformance.standards.jit.model.JitGetTerminalCallFilters;
 import org.dcsa.conformance.standards.jit.model.JitGetType;
 import org.dcsa.conformance.standards.jit.model.JitServiceTypeSelector;
@@ -788,14 +789,26 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
             .thenEither(
                 portCall(context).then(getPortCallActions(context, false)),
                 portCall(context)
-                    .then(terminalCall(context).then(getTerminalCallActions(context, false)))));
+                    .then(terminalCall(context).then(getTerminalCallActions(context, false))),
+                portCall(context)
+                    .then(
+                        terminalCall(context)
+                            .then(
+                                serviceCall(context, null, ANY)
+                                    .then(getServiceCallActions(context, false))))));
     scenarioList.put(
         "2. PC-TC-S-V Consumer answering GET calls",
         supplyScenarioParameters(context, ANY)
             .thenEither(
                 portCall(context).then(getPortCallActions(context, true)),
                 portCall(context)
-                    .then(terminalCall(context).then(getTerminalCallActions(context, true)))));
+                    .then(terminalCall(context).then(getTerminalCallActions(context, true))),
+                portCall(context)
+                    .then(
+                        terminalCall(context)
+                            .then(
+                                serviceCall(context, null, ANY)
+                                    .then(getServiceCallActions(context, true))))));
   }
 
   private static JitScenarioListBuilder getPortCallActions(
@@ -922,6 +935,29 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
                                                                                         .props()
                                                                                         .get(9)),
                                                                                 requestedByProvider))))))))));
+  }
+
+  private static JitScenarioListBuilder getServiceCallActions(
+      JitScenarioContext context, boolean requestedByProvider) {
+    return getAction(
+            context,
+            JitGetType.PORT_CALL_SERVICES,
+            JitGetPortServiceCallFilters.props().getFirst(),
+            requestedByProvider)
+        .then(
+            getAction(
+                    context,
+                    JitGetType.PORT_CALL_SERVICES,
+                    JitGetPortServiceCallFilters.props().get(1),
+                    requestedByProvider)
+                .then(
+                    getAction(
+                        context,
+                        JitGetType.PORT_CALL_SERVICES,
+                        List.of(
+                            JitGetPortServiceCallFilters.props().getFirst(),
+                            JitGetPortServiceCallFilters.props().get(2)),
+                        requestedByProvider)));
   }
 
   private static void addScenarioGroupSecondary1(

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/JitScenarioListBuilder.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/JitScenarioListBuilder.java
@@ -83,6 +83,8 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
     addScenarioGroup10(scenarioList, context);
     addScenarioGroup11(scenarioList, context);
     addScenarioGroup12(scenarioList, context);
+    addScenarioGroup13(scenarioList, context);
+    addScenarioGroup14(scenarioList, context);
 
     // Scenario suite: "GET endpoint conformance"
     addScenarioGroupGET1(scenarioList, context);
@@ -98,98 +100,37 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
   private static void addScenarioGroup3(
       LinkedHashMap<String, JitScenarioListBuilder> scenarioList, JitScenarioContext context) {
     scenarioList.put(
-        "3. S-service type with variations (Moves only)",
+        "3. Moves type with variations",
         supplyScenarioParameters(context, GIVEN)
             .thenEither(
                 portCall(context)
-                    .then(
-                        terminalCall(context)
-                            .then(serviceCall(context, MOVES, GIVEN).then(vesselStatus(context)))),
+                    .then(terminalCall(context).then(serviceCall(context, MOVES, GIVEN))),
                 portCall(context)
                     .then(
                         portCall(context)
-                            .then(
-                                terminalCall(context)
-                                    .then(
-                                        serviceCall(context, MOVES, GIVEN)
-                                            .then(vesselStatus(context))))),
+                            .then(terminalCall(context).then(serviceCall(context, MOVES, GIVEN)))),
                 portCall(context)
                     .then(
                         terminalCall(context)
-                            .then(
-                                portCall(context)
-                                    .then(
-                                        serviceCall(context, MOVES, GIVEN)
-                                            .then(vesselStatus(context))))),
+                            .then(portCall(context).then(serviceCall(context, MOVES, GIVEN)))),
                 portCall(context)
                     .then(
                         terminalCall(context)
-                            .then(
-                                serviceCall(context, MOVES, GIVEN)
-                                    .then(portCall(context).then(vesselStatus(context))))),
+                            .then(serviceCall(context, MOVES, GIVEN).then(portCall(context)))),
                 portCall(context)
                     .then(
                         terminalCall(context)
-                            .then(
-                                serviceCall(context, MOVES, GIVEN)
-                                    .then(vesselStatus(context).then(portCall(context))))),
+                            .then(terminalCall(context).then(serviceCall(context, MOVES, GIVEN)))),
                 portCall(context)
                     .then(
                         terminalCall(context)
-                            .then(
-                                terminalCall(context)
-                                    .then(
-                                        serviceCall(context, MOVES, GIVEN)
-                                            .then(vesselStatus(context))))),
+                            .then(serviceCall(context, MOVES, GIVEN).then(terminalCall(context)))),
                 portCall(context)
                     .then(
                         terminalCall(context)
                             .then(
                                 serviceCall(context, MOVES, GIVEN)
-                                    .then(terminalCall(context).then(vesselStatus(context))))),
-                portCall(context)
-                    .then(
-                        terminalCall(context)
-                            .then(
-                                serviceCall(context, MOVES, GIVEN)
-                                    .then(vesselStatus(context).then(terminalCall(context))))),
-                portCall(context)
-                    .then(
-                        terminalCall(context)
-                            .then(
-                                serviceCall(context, MOVES, GIVEN)
-                                    .then(
-                                        serviceCall(context, MOVES, GIVEN)
-                                            .then(vesselStatus(context))))),
-                portCall(context)
-                    .then(
-                        terminalCall(context)
-                            .then(
-                                serviceCall(context, MOVES, GIVEN)
-                                    .then(
-                                        vesselStatus(context)
-                                            .then(serviceCall(context, MOVES, GIVEN))))),
-                portCall(context)
-                    .then(
-                        terminalCall(context)
-                            .then(
-                                serviceCall(context, MOVES, GIVEN)
-                                    .then(vesselStatus(context).then(vesselStatus(context))))),
-                portCall(context)
-                    .then(
-                        terminalCall(context)
-                            .then(
-                                serviceCall(context, MOVES, GIVEN)
-                                    .then(vesselStatus(context).then(cancelCall(context))))),
-                portCall(context)
-                    .then(
-                        terminalCall(context)
-                            .then(serviceCall(context, MOVES, GIVEN).then(cancelCall(context)))),
-                sendPC_TC_SC_VS(context, MOVES, GIVEN, declineCall(context)),
-                portCall(context)
-                    .then(
-                        terminalCall(context)
-                            .then(serviceCall(context, MOVES, GIVEN).then(declineCall(context))))));
+                                    .then(serviceCall(context, MOVES, GIVEN))))));
   }
 
   private static void addScenarioGroup4(
@@ -703,7 +644,15 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
                     context,
                     null,
                     S_A_PATTERN,
-                    sendTimestamp(context, ACTUAL).then(sendTimestamp(context, ACTUAL))),
+                    sendTimestamp(context, ACTUAL).then(sendTimestamp(context, ACTUAL)))));
+  }
+
+  private static void addScenarioGroup11(
+      LinkedHashMap<String, JitScenarioListBuilder> scenarioList, JitScenarioContext context) {
+    scenarioList.put(
+        "11. S-A cancel",
+        supplyScenarioParameters(context, S_A_PATTERN)
+            .thenEither(
                 sendPC_TC_SC_VS(
                     context,
                     null,
@@ -714,7 +663,16 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
                     .then(
                         terminalCall(context)
                             .then(
-                                serviceCall(context, null, S_A_PATTERN).then(cancelCall(context)))),
+                                serviceCall(context, null, S_A_PATTERN)
+                                    .then(cancelCall(context))))));
+  }
+
+  private static void addScenarioGroup12(
+      LinkedHashMap<String, JitScenarioListBuilder> scenarioList, JitScenarioContext context) {
+    scenarioList.put(
+        "12. S-A decline",
+        supplyScenarioParameters(context, S_A_PATTERN)
+            .thenEither(
                 sendPC_TC_SC_VS(
                     context,
                     null,
@@ -729,10 +687,10 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
                                     .then(declineCall(context))))));
   }
 
-  private static void addScenarioGroup11(
+  private static void addScenarioGroup13(
       LinkedHashMap<String, JitScenarioListBuilder> scenarioList, JitScenarioContext context) {
     scenarioList.put(
-        "11. S-ERP-A cancel",
+        "13. S-ERP-A cancel",
         supplyScenarioParameters(context, FULL_ERP)
             .thenEither(
                 sendPC_TC_SC_VS(
@@ -756,10 +714,10 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
                                 serviceCall(context, null, FULL_ERP).then(cancelCall(context))))));
   }
 
-  private static void addScenarioGroup12(
+  private static void addScenarioGroup14(
       LinkedHashMap<String, JitScenarioListBuilder> scenarioList, JitScenarioContext context) {
     scenarioList.put(
-        "12. S-ERP-A decline",
+        "14. S-ERP-A decline",
         supplyScenarioParameters(context, FULL_ERP)
             .thenEither(
                 sendPC_TC_SC_VS(
@@ -1245,21 +1203,21 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
   private static void addScenarioGroupSecondary3(
       LinkedHashMap<String, JitScenarioListBuilder> scenarioList, JitScenarioContext context) {
     scenarioList.put(
-        "3. S(Moves) as FYI message",
+        "3. Moves as FYI message",
         supplyScenarioParameters(context, GIVEN, true)
             .thenEither(
-                sendPC_TC_SC_VS(context, MOVES, null),
-                sendPC_TC_SC_VS(context, MOVES, null, omitPortCall(context)),
-                sendPC_TC_SC_VS(context, MOVES, null, omitTerminalCall(context)),
+                portCall(context)
+                    .then(terminalCall(context).then(serviceCall(context, MOVES, GIVEN))),
                 portCall(context)
                     .then(
                         terminalCall(context)
-                            .then(serviceCall(context, MOVES, null).then(omitPortCall(context)))),
+                            .then(serviceCall(context, MOVES, GIVEN).then(omitPortCall(context)))),
                 portCall(context)
                     .then(
                         terminalCall(context)
                             .then(
-                                serviceCall(context, MOVES, null).then(omitTerminalCall(context)))),
+                                serviceCall(context, MOVES, GIVEN)
+                                    .then(omitTerminalCall(context)))),
                 portCall(context).then(terminalCall(context).then(omitPortCall(context))),
                 portCall(context).then(terminalCall(context).then(omitTerminalCall(context))),
                 portCall(context).then(omitPortCall(context))));

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/JitScenarioListBuilder.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/JitScenarioListBuilder.java
@@ -29,6 +29,7 @@ import org.dcsa.conformance.standards.jit.checks.JitChecks;
 import org.dcsa.conformance.standards.jit.model.JitGetPortCallFilters;
 import org.dcsa.conformance.standards.jit.model.JitGetPortServiceCallFilters;
 import org.dcsa.conformance.standards.jit.model.JitGetTerminalCallFilters;
+import org.dcsa.conformance.standards.jit.model.JitGetTimestampCallFilters;
 import org.dcsa.conformance.standards.jit.model.JitGetType;
 import org.dcsa.conformance.standards.jit.model.JitServiceTypeSelector;
 import org.dcsa.conformance.standards.jit.model.JitTimestampType;
@@ -828,6 +829,57 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
                         JitGetType.VESSEL_STATUSES,
                         JitChecks.PORT_CALL_SERVICE_ID,
                         true))));
+
+    scenarioList.put(
+        "3. PC-TC-S-V-A-ERP-A Provider answering GET calls",
+        supplyScenarioParameters(context, ANY)
+            .thenEither(
+                sendPC_TC_SC_VS(
+                    context,
+                    null,
+                    FULL_ERP,
+                    sendERPTimestamps(
+                        context,
+                        sendTimestamp(context, ACTUAL)
+                            .then(getTimestampActions(context, false))))));
+  }
+
+  private static JitScenarioListBuilder getTimestampActions(
+      JitScenarioContext context, boolean requestedByProvider) {
+    return getAction(
+            context, JitGetType.TIMESTAMPS, JitGetTimestampCallFilters.props().getFirst(), false)
+        .then(
+            getAction(
+                    context,
+                    JitGetType.TIMESTAMPS,
+                    JitGetTimestampCallFilters.props().get(1),
+                    requestedByProvider)
+                .then(
+                    getAction(
+                            context,
+                            JitGetType.TIMESTAMPS,
+                            JitGetTimestampCallFilters.props().get(2),
+                            requestedByProvider)
+                        .then(
+                            getAction(
+                                    context,
+                                    JitGetType.TIMESTAMPS,
+                                    JitGetTimestampCallFilters.props().get(3),
+                                    requestedByProvider)
+                                .then(
+                                    getAction(
+                                            context,
+                                            JitGetType.TIMESTAMPS,
+                                            JitGetTimestampCallFilters.props().get(4),
+                                            requestedByProvider)
+                                        .then(
+                                            getAction(
+                                                context,
+                                                JitGetType.TIMESTAMPS,
+                                                List.of(
+                                                    JitGetTimestampCallFilters.props().get(4),
+                                                    JitGetTimestampCallFilters.props().get(5)),
+                                                requestedByProvider))))));
   }
 
   private static JitScenarioListBuilder getPortCallActions(

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/JitStandard.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/JitStandard.java
@@ -25,6 +25,7 @@ public class JitStandard extends AbstractStandard {
   public static final String PORT_CALL_SERVICE_ID = "{portCallServiceID}";
   public static final String PORT_CALL_ID = "{portCallID}";
   public static final String TERMINAL_CALL_ID = "{terminalCallID}";
+  public static final String TIMESTAMP_ID = "{timestampID}";
 
   private JitStandard() {
     super("JIT");
@@ -54,17 +55,17 @@ public class JitStandard extends AbstractStandard {
                             createEntry(PORT_CALL_URL, GET),
                             createEntry(TERMINAL_CALL_URL, GET),
                             createEntry(PORT_CALL_SERVICES_URL, GET),
-                            createEntry(TIMESTAMP_URL + "${timestampID}", PUT),
+                            createEntry(TIMESTAMP_URL + TIMESTAMP_ID, PUT),
                             createEntry(TIMESTAMP_URL, GET),
                             createEntry(VESSEL_STATUS_URL, GET)))),
                 Map.entry(
                     JitRole.CONSUMER.getConfigName(),
                     new TreeMap<>(
                         Map.ofEntries(
-                            createEntry(PORT_CALL_URL + "{portCallID}", PUT),
-                            createEntry(PORT_CALL_URL + "{portCallID}/omit", POST),
-                            createEntry(TERMINAL_CALL_URL + "{terminalCallId}", PUT),
-                            createEntry(TERMINAL_CALL_URL + "{terminalCallId}/omit", POST),
+                            createEntry(PORT_CALL_URL + PORT_CALL_ID, PUT),
+                            createEntry(PORT_CALL_URL + PORT_CALL_ID + "/omit", POST),
+                            createEntry(TERMINAL_CALL_URL + TERMINAL_CALL_ID, PUT),
+                            createEntry(TERMINAL_CALL_URL + TERMINAL_CALL_ID + "/omit", POST),
                             createEntry(PORT_CALL_SERVICES_URL + PORT_CALL_SERVICE_ID, PUT),
                             createEntry(
                                 PORT_CALL_SERVICES_URL + PORT_CALL_SERVICE_ID + "/cancel", POST),
@@ -73,7 +74,7 @@ public class JitStandard extends AbstractStandard {
                             createEntry(PORT_CALL_URL, GET),
                             createEntry(TERMINAL_CALL_URL, GET),
                             createEntry(PORT_CALL_SERVICES_URL, GET),
-                            createEntry(TIMESTAMP_URL + "${timestampID}", PUT),
+                            createEntry(TIMESTAMP_URL + TIMESTAMP_ID, PUT),
                             createEntry(TIMESTAMP_URL, GET),
                             createEntry(VESSEL_STATUS_URL, GET)))))));
   }

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitGetAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitGetAction.java
@@ -1,0 +1,117 @@
+package org.dcsa.conformance.standards.jit.action;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.dcsa.conformance.core.check.ActionCheck;
+import org.dcsa.conformance.core.check.ApiHeaderCheck;
+import org.dcsa.conformance.core.check.ConformanceCheck;
+import org.dcsa.conformance.core.check.HttpMethodCheck;
+import org.dcsa.conformance.core.check.JsonSchemaCheck;
+import org.dcsa.conformance.core.check.JsonSchemaValidator;
+import org.dcsa.conformance.core.check.ResponseStatusCheck;
+import org.dcsa.conformance.core.check.UrlPathCheck;
+import org.dcsa.conformance.core.scenario.ConformanceAction;
+import org.dcsa.conformance.core.traffic.HttpMessageType;
+import org.dcsa.conformance.standards.jit.JitScenarioContext;
+import org.dcsa.conformance.standards.jit.JitStandard;
+import org.dcsa.conformance.standards.jit.checks.JitChecks;
+import org.dcsa.conformance.standards.jit.model.JitGetType;
+import org.dcsa.conformance.standards.jit.party.JitRole;
+
+@Slf4j
+public class JitGetAction extends JitAction {
+  public static final String GET_TYPE = "getType";
+  public static final String FILTERS = "filters";
+
+  private final JitGetType getType;
+  private final JsonSchemaValidator validator;
+  private final boolean requestedByProvider;
+  private final List<String> urlFilters;
+
+  public JitGetAction(
+      JitScenarioContext context,
+      ConformanceAction previousAction,
+      JitGetType getType,
+      List<String> urlFilters,
+      boolean requestedByProvider) {
+    super(
+        requestedByProvider ? context.providerPartyName() : context.consumerPartyName(),
+        requestedByProvider ? context.consumerPartyName() : context.providerPartyName(),
+        previousAction,
+        requestedByProvider
+            ? "Send GET %s by %s".formatted(getType.getName(), urlFilters)
+            : "GET %s by %s".formatted(getType.getName(), urlFilters));
+    this.getType = getType;
+    this.urlFilters = urlFilters;
+    this.requestedByProvider = requestedByProvider;
+    validator = context.componentFactory().getMessageSchemaValidator(getType.getJitSchema());
+  }
+
+  @Override
+  public ObjectNode asJsonNode() {
+    ObjectNode jsonNode = super.asJsonNode();
+    jsonNode.put(GET_TYPE, getType.name());
+    jsonNode.putPOJO(FILTERS, urlFilters);
+    return jsonNode;
+  }
+
+  @Override
+  public String getHumanReadablePrompt() {
+    return "Get %s (GET) request".formatted(getType);
+  }
+
+  @Override
+  public ConformanceCheck createCheck(String expectedApiVersion) {
+    return new ConformanceCheck(getActionTitle()) {
+      @Override
+      protected Stream<? extends ConformanceCheck> createSubChecks() {
+        if (dsp == null) return Stream.of();
+        ActionCheck checksForTimestamp =
+            JitChecks.createChecksForTimestamp(
+                JitRole::isProvider, getMatchedExchangeUuid(), expectedApiVersion, dsp);
+        if (requestedByProvider) {
+          return Stream.of(
+              new UrlPathCheck(JitRole::isProvider, getMatchedExchangeUuid(), getType.getUrlPath()),
+              new HttpMethodCheck(JitRole::isProvider, getMatchedExchangeUuid(), JitStandard.GET),
+              new ResponseStatusCheck(JitRole::isConsumer, getMatchedExchangeUuid(), 200),
+              new ApiHeaderCheck(
+                  JitRole::isProvider,
+                  getMatchedExchangeUuid(),
+                  HttpMessageType.REQUEST,
+                  expectedApiVersion),
+              new ApiHeaderCheck(
+                  JitRole::isConsumer,
+                  getMatchedExchangeUuid(),
+                  HttpMessageType.RESPONSE,
+                  expectedApiVersion),
+              new JsonSchemaCheck(
+                  JitRole::isConsumer,
+                  getMatchedExchangeUuid(),
+                  HttpMessageType.RESPONSE,
+                  validator),
+              checksForTimestamp);
+        }
+        // Consumer sends request
+        return Stream.of(
+            new UrlPathCheck(JitRole::isConsumer, getMatchedExchangeUuid(), getType.getUrlPath()),
+            new HttpMethodCheck(JitRole::isConsumer, getMatchedExchangeUuid(), JitStandard.GET),
+            new ResponseStatusCheck(JitRole::isProvider, getMatchedExchangeUuid(), 200),
+            new ApiHeaderCheck(
+                JitRole::isConsumer,
+                getMatchedExchangeUuid(),
+                HttpMessageType.REQUEST,
+                expectedApiVersion),
+            new ApiHeaderCheck(
+                JitRole::isProvider,
+                getMatchedExchangeUuid(),
+                HttpMessageType.RESPONSE,
+                expectedApiVersion),
+            new JsonSchemaCheck(
+                JitRole::isProvider, getMatchedExchangeUuid(), HttpMessageType.RESPONSE, validator),
+            checksForTimestamp);
+      }
+    };
+  }
+}

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitGetAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitGetAction.java
@@ -42,7 +42,7 @@ public class JitGetAction extends JitAction {
         previousAction,
         requestedByProvider
             ? "Send GET %s by %s".formatted(getType.getName(), urlFilters)
-            : "GET %s by %s".formatted(getType.getName(), urlFilters));
+            : "Receive GET %s by %s".formatted(getType.getName(), urlFilters));
     this.getType = getType;
     this.urlFilters = urlFilters;
     this.requestedByProvider = requestedByProvider;

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitPortCallAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitPortCallAction.java
@@ -54,7 +54,9 @@ public class JitPortCallAction extends JitAction {
         if (dsp == null) return Stream.of();
         return Stream.of(
             new UrlPathCheck(
-                JitRole::isProvider, getMatchedExchangeUuid(), JitStandard.PORT_CALL_URL + dsp.portCallID()),
+                JitRole::isProvider,
+                getMatchedExchangeUuid(),
+                JitStandard.PORT_CALL_URL + dsp.portCallID()),
             new HttpMethodCheck(JitRole::isProvider, getMatchedExchangeUuid(), JitStandard.PUT),
             new ResponseStatusCheck(JitRole::isConsumer, getMatchedExchangeUuid(), 204),
             new ApiHeaderCheck(

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitPortCallServiceAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitPortCallServiceAction.java
@@ -84,6 +84,8 @@ public class JitPortCallServiceAction extends JitAction {
         yield "Send a Port Call Service (PUT) for the %s".formatted(dsp.selector().getFullName());
       case GIVEN:
         yield "Send a Port Call Service (PUT) for %s".formatted(serviceType.name());
+      case ANY:
+        yield "Send a Port Call Service (PUT) for a service you supply";
     };
   }
 

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/checks/JitChecks.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/checks/JitChecks.java
@@ -31,6 +31,8 @@ public class JitChecks {
   public static final String TERMINAL_CALL_ID = "terminalCallID";
   public static final String PORT_CALL_ID = "portCallID";
   public static final String PORT_CALL_SERVICE_ID = "portCallServiceID";
+  public static final String TIMESTAMP_ID = "timestampID";
+  public static final String CLASSIFIER_CODE = "classifierCode";
 
   static final JsonRebaseableContentCheck IS_FYI_TRUE =
       JsonAttribute.mustEqual(

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/checks/JitChecks.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/checks/JitChecks.java
@@ -49,7 +49,9 @@ public class JitChecks {
     if (serviceType != null) {
       checks.add(checkPortCallService(serviceType));
     }
-    if (dsp != null && dsp.selector() != JitServiceTypeSelector.GIVEN) {
+    if (dsp != null
+        && dsp.selector() != JitServiceTypeSelector.GIVEN
+        && dsp.selector() != JitServiceTypeSelector.ANY) {
       checks.add(checkPortCallServiceRightType(dsp));
     }
     checks.add(JitChecks.checkIDsMatchesPreviousCall(dsp));

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/model/JitGetPortCallFilters.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/model/JitGetPortCallFilters.java
@@ -1,0 +1,20 @@
+package org.dcsa.conformance.standards.jit.model;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+
+public record JitGetPortCallFilters(
+    String portCallID,
+    String portVisitReference,
+    String UNLocationCode,
+    String vesselIMONumber,
+    String vesselName,
+    String MMSINumber) {
+
+  public static List<String> props() {
+    return Arrays.stream(JitGetPortCallFilters.class.getDeclaredFields())
+        .map(Field::getName)
+        .toList();
+  }
+}

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/model/JitGetPortServiceCallFilters.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/model/JitGetPortServiceCallFilters.java
@@ -1,0 +1,15 @@
+package org.dcsa.conformance.standards.jit.model;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+
+public record JitGetPortServiceCallFilters(
+    String terminalCallID, String portCallServiceID, String portCallServiceType) {
+
+  public static List<String> props() {
+    return Arrays.stream(JitGetPortServiceCallFilters.class.getDeclaredFields())
+        .map(Field::getName)
+        .toList();
+  }
+}

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/model/JitGetTerminalCallFilters.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/model/JitGetTerminalCallFilters.java
@@ -1,0 +1,24 @@
+package org.dcsa.conformance.standards.jit.model;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+
+public record JitGetTerminalCallFilters(
+    String portCallID,
+    String terminalCallID,
+    String carrierServiceName,
+    String carrierServiceCode,
+    String universalServiceReference,
+    String terminalCallReference,
+    String carrierImportVoyageNumber,
+    String carrierExportVoyageNumber,
+    String universalImportVoyageReference,
+    String universalExportVoyageReference) {
+
+  public static List<String> props() {
+    return Arrays.stream(JitGetTerminalCallFilters.class.getDeclaredFields())
+        .map(Field::getName)
+        .toList();
+  }
+}

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/model/JitGetTimestampCallFilters.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/model/JitGetTimestampCallFilters.java
@@ -1,0 +1,20 @@
+package org.dcsa.conformance.standards.jit.model;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+
+public record JitGetTimestampCallFilters(
+    String timestampID_Estimated,
+    String timestampID_Requested,
+    String timestampID_Planned,
+    String timestampID_Actual,
+    String portCallServiceID,
+    String classifierCode) {
+
+  public static List<String> props() {
+    return Arrays.stream(JitGetTimestampCallFilters.class.getDeclaredFields())
+        .map(Field::getName)
+        .toList();
+  }
+}

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/model/JitGetType.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/model/JitGetType.java
@@ -1,0 +1,35 @@
+package org.dcsa.conformance.standards.jit.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.dcsa.conformance.standards.jit.JitStandard;
+
+@Getter
+@RequiredArgsConstructor
+public enum JitGetType {
+  PORT_CALLS(
+      "Port Calls",
+      JitSchema.PORT_CALLS,
+      JitStandard.PORT_CALL_URL.substring(0, JitStandard.PORT_CALL_URL.length() - 1)),
+  TERMINAL_CALLS(
+      "Terminal Calls",
+      JitSchema.TERMINAL_CALLS,
+      JitStandard.TERMINAL_CALL_URL.substring(0, JitStandard.TERMINAL_CALL_URL.length() - 1)),
+  PORT_CALL_SERVICES(
+      "Port Call Services",
+      JitSchema.PORT_CALL_SERVICES,
+      JitStandard.PORT_CALL_SERVICES_URL.substring(
+          0, JitStandard.PORT_CALL_SERVICES_URL.length() - 1)),
+  TIMESTAMPS(
+      "Timestamps",
+      JitSchema.TIMESTAMPS,
+      JitStandard.TIMESTAMP_URL.substring(0, JitStandard.TIMESTAMP_URL.length() - 1)),
+  VESSEL_STATUSES(
+      "Vessel Statuses",
+      JitSchema.VESSEL_STATUSES,
+      JitStandard.VESSEL_STATUS_URL.substring(0, JitStandard.VESSEL_STATUS_URL.length() - 1));
+
+  private final String name;
+  private final JitSchema jitSchema;
+  private final String urlPath;
+}

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/model/JitSchema.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/model/JitSchema.java
@@ -19,6 +19,12 @@ public enum JitSchema {
   MOVES("Moves"),
   OMIT_PORT_CALL("OmitPortCall"),
   OMIT_TERMINAL_CALL("OmitTerminalCall"),
+  // GET actions
+  PORT_CALLS("PortCalls"),
+  TERMINAL_CALLS("TerminalCalls"),
+  PORT_CALL_SERVICES("PortCallServices"),
+  TIMESTAMPS("Timestamps"),
+  VESSEL_STATUSES("VesselStatuses"),
   ;
 
   private final String schemaName;

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/model/JitServiceTypeSelector.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/model/JitServiceTypeSelector.java
@@ -9,6 +9,7 @@ public enum JitServiceTypeSelector {
   GIVEN("Given"),
   FULL_ERP("full ERP"),
   S_A_PATTERN("S-A pattern"),
+  ANY("Any")
   ;
 
   private final String fullName;

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitConsumer.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitConsumer.java
@@ -118,6 +118,7 @@ public class JitConsumer extends ConformanceParty {
         JitTimestamp.getTimestampForType(timestampType, dsp.currentTimestamp(), dsp.isFYI());
 
     syncCounterpartPut(JitStandard.TIMESTAMP_URL + timestamp.timestampID(), timestamp.toJson());
+    JitPartyHelper.storeTimestamp(persistentMap, timestamp);
 
     addOperatorLogEntry(
         "Submitted %s timestamp for: %s".formatted(timestampType, timestamp.dateTime()));
@@ -172,6 +173,7 @@ public class JitConsumer extends ConformanceParty {
     JitPartyHelper.createParamsForTerminalCall(persistentMap, getType, filters, queryParams);
     JitPartyHelper.createParamsForPortServiceCall(persistentMap, getType, filters, queryParams);
     JitPartyHelper.createParamsForVesselStatusCall(persistentMap, getType, filters, queryParams);
+    JitPartyHelper.createParamsForTimestampCall(persistentMap, getType, filters, queryParams);
 
     syncCounterpartGet(getType.getUrlPath(), queryParams);
     addOperatorLogEntry(
@@ -198,6 +200,7 @@ public class JitConsumer extends ConformanceParty {
               .formatted(
                   JitTimestampType.fromClassifierCode(timestamp.classifierCode()),
                   timestamp.dateTime()));
+      JitPartyHelper.storeTimestamp(persistentMap, timestamp);
     } else if (url.endsWith("/cancel")) {
       addOperatorLogEntry("Handled Cancel request accepted.");
     } else if (url.endsWith("/omit")) {

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitConsumer.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitConsumer.java
@@ -170,6 +170,7 @@ public class JitConsumer extends ConformanceParty {
     Map<String, List<String>> queryParams = new HashMap<>();
     JitPartyHelper.createParamsForPortCall(persistentMap, getType, filters, queryParams);
     JitPartyHelper.createParamsForTerminalCall(persistentMap, getType, filters, queryParams);
+    JitPartyHelper.createParamsForPortServiceCall(persistentMap, getType, filters, queryParams);
 
     syncCounterpartGet(getType.getUrlPath(), queryParams);
     addOperatorLogEntry(
@@ -185,11 +186,12 @@ public class JitConsumer extends ConformanceParty {
     }
     int statusCode = 204;
     String url = request.url();
-    if (request.message().body().getJsonBody().isEmpty()) {
+    JsonNode jsonBody = request.message().body().getJsonBody();
+    if (jsonBody.isEmpty()) {
       addOperatorLogEntry("Handled an empty request, which is wrong.");
       statusCode = 400;
     } else if (url.contains(JitStandard.TIMESTAMP_URL)) {
-      JitTimestamp timestamp = JitTimestamp.fromJson(request.message().body().getJsonBody());
+      JitTimestamp timestamp = JitTimestamp.fromJson(jsonBody);
       addOperatorLogEntry(
           "Handled %s timestamp accepted for: %s"
               .formatted(
@@ -203,12 +205,13 @@ public class JitConsumer extends ConformanceParty {
       addOperatorLogEntry("Handled Decline request accepted.");
     } else if (url.contains(JitStandard.PORT_CALL_URL)) {
       addOperatorLogEntry("Handled Port Call request accepted.");
-      persistentMap.save(JitGetType.PORT_CALLS.name(), request.message().body().getJsonBody());
-    } else if (url.contains(JitStandard.PORT_CALL_SERVICES_URL)) {
-      addOperatorLogEntry("Handled Port Call Service request accepted.");
+      persistentMap.save(JitGetType.PORT_CALLS.name(), jsonBody);
     } else if (url.contains(JitStandard.TERMINAL_CALL_URL)) {
       addOperatorLogEntry("Handled Terminal Call request accepted.");
-      persistentMap.save(JitGetType.TERMINAL_CALLS.name(), request.message().body().getJsonBody());
+      persistentMap.save(JitGetType.TERMINAL_CALLS.name(), jsonBody);
+    } else if (url.contains(JitStandard.PORT_CALL_SERVICES_URL)) {
+      addOperatorLogEntry("Handled Port Call Service request accepted.");
+      persistentMap.save(JitGetType.PORT_CALL_SERVICES.name(), jsonBody);
     } else if (url.contains(JitStandard.VESSEL_STATUS_URL)) {
       addOperatorLogEntry("Handled Vessel Status request accepted.");
     } else {

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitConsumer.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitConsumer.java
@@ -85,6 +85,8 @@ public class JitConsumer extends ConformanceParty {
 
     addOperatorLogEntry(
         "Submitted SuppliedScenarioParameters: %s".formatted(parameters.toJson().toPrettyString()));
+
+    JitPartyHelper.flushTimestamps(persistentMap); // Prevent timestamps from being reused
   }
 
   public static SuppliedScenarioParameters createSuppliedScenarioParameters(

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitConsumer.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitConsumer.java
@@ -171,6 +171,7 @@ public class JitConsumer extends ConformanceParty {
     JitPartyHelper.createParamsForPortCall(persistentMap, getType, filters, queryParams);
     JitPartyHelper.createParamsForTerminalCall(persistentMap, getType, filters, queryParams);
     JitPartyHelper.createParamsForPortServiceCall(persistentMap, getType, filters, queryParams);
+    JitPartyHelper.createParamsForVesselStatusCall(persistentMap, getType, filters, queryParams);
 
     syncCounterpartGet(getType.getUrlPath(), queryParams);
     addOperatorLogEntry(
@@ -214,6 +215,7 @@ public class JitConsumer extends ConformanceParty {
       persistentMap.save(JitGetType.PORT_CALL_SERVICES.name(), jsonBody);
     } else if (url.contains(JitStandard.VESSEL_STATUS_URL)) {
       addOperatorLogEntry("Handled Vessel Status request accepted.");
+      persistentMap.save(JitGetType.VESSEL_STATUSES.name(), jsonBody);
     } else {
       addOperatorLogEntry("Handled an unknown request, which is wrong.");
       statusCode = 400;

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitPartyHelper.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitPartyHelper.java
@@ -1,0 +1,116 @@
+package org.dcsa.conformance.standards.jit.party;
+
+import static org.dcsa.conformance.core.party.ConformanceParty.API_VERSION;
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.dcsa.conformance.core.party.ConformanceParty;
+import org.dcsa.conformance.core.state.JsonNodeMap;
+import org.dcsa.conformance.core.toolkit.JsonToolkit;
+import org.dcsa.conformance.core.traffic.ConformanceMessageBody;
+import org.dcsa.conformance.core.traffic.ConformanceRequest;
+import org.dcsa.conformance.core.traffic.ConformanceResponse;
+import org.dcsa.conformance.standards.jit.model.JitGetPortCallFilters;
+import org.dcsa.conformance.standards.jit.model.JitGetType;
+import org.dcsa.conformance.standards.jit.model.PortCallPhaseTypeCode;
+import org.dcsa.conformance.standards.jit.model.PortCallServiceEventTypeCode;
+import org.dcsa.conformance.standards.jit.model.PortCallServiceType;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class JitPartyHelper {
+
+  static ConformanceResponse handleGetRequest(
+      ConformanceRequest request,
+      JsonNodeMap persistentMap,
+      String apiVersion,
+      ConformanceParty jitConsumer) {
+    JsonNode response;
+    if (request.url().contains(JitGetType.PORT_CALLS.getUrlPath())) {
+      ObjectNode portCall = (ObjectNode) persistentMap.load(JitGetType.PORT_CALLS.name());
+      portCall.remove(JitProvider.IS_FYI);
+      response = OBJECT_MAPPER.createArrayNode().add(portCall);
+      jitConsumer.addOperatorLogEntry("Handled Port Call Service request accepted.");
+    } else {
+      response = OBJECT_MAPPER.createArrayNode();
+    }
+
+    return request.createResponse(
+        200, Map.of(API_VERSION, List.of(apiVersion)), new ConformanceMessageBody(response));
+  }
+
+  static void createParamsForPortCall(
+      JsonNodeMap persistentMap,
+      JitGetType getType,
+      List<String> filters,
+      Map<String, List<String>> queryParams) {
+    if (getType != JitGetType.PORT_CALLS) return;
+
+    JsonNode portCall = persistentMap.load(JitGetType.PORT_CALLS.name());
+    JsonNode vessel = portCall.path("vessel");
+    for (int i = 0; i < JitGetPortCallFilters.props().size(); i++) {
+      String propertyName = JitGetPortCallFilters.props().get(i);
+      if (filters.contains(propertyName)) {
+        // The first 3 properties are in the portCall.
+        if (i < 3) queryParams.put(propertyName, List.of(portCall.get(propertyName).asText()));
+        else { // The rest are in the vessel.
+          String propertyValue;
+          if (propertyName.equals("vesselName"))
+            propertyValue = vessel.get("name").asText(); // property has different filter name.
+          else propertyValue = vessel.get(propertyName).asText();
+          queryParams.put(propertyName, List.of(propertyValue));
+        }
+      }
+    }
+  }
+
+  static JsonNode replacePlaceHolders(String fileType, DynamicScenarioParameters dsp) {
+    PortCallServiceType serviceType = dsp.portCallServiceType();
+    String portCallPhaseTypeCode = "";
+    String portCallServiceEventTypeCode = "";
+    if (serviceType != null) {
+      portCallPhaseTypeCode = calculatePortCallPhaseTypeCode(serviceType.name());
+      portCallServiceEventTypeCode =
+          PortCallServiceEventTypeCode.getCodesForPortCallServiceType(serviceType.name())
+              .getFirst()
+              .name();
+    }
+
+    JsonNode jsonNode =
+        JsonToolkit.templateFileToJsonNode(
+            "/standards/jit/messages/jit-200-%s-request.json".formatted(fileType),
+            Map.of(
+                "PORT_CALL_ID_PLACEHOLDER",
+                Objects.requireNonNullElse(dsp.portCallID(), ""),
+                "TERMINAL_CALL_ID_PLACEHOLDER",
+                Objects.requireNonNullElse(dsp.terminalCallID(), ""),
+                "PORT_CALL_SERVICE_TYPE_PLACEHOLDER",
+                serviceType != null ? serviceType.name() : "",
+                "PORT_CALL_SERVICE_ID_PLACEHOLDER",
+                Objects.requireNonNullElse(dsp.portCallServiceID(), ""),
+                "PORT_CALL_SERVICE_EVENT_TYPE_CODE_PLACEHOLDER",
+                portCallServiceEventTypeCode,
+                "PORT_CALL_PHASE_TYPE_CODE_PLACEHOLDER",
+                portCallPhaseTypeCode,
+                "IS_FYI_PLACEHOLDER",
+                Boolean.toString(dsp.isFYI())));
+    // Some serviceType do not have a portCallPhaseTypeCode; remove it, since it is an enum.
+    if (serviceType != null && portCallPhaseTypeCode.isEmpty())
+      ((ObjectNode) jsonNode).remove("portCallPhaseTypeCode");
+    return jsonNode;
+  }
+
+  private static String calculatePortCallPhaseTypeCode(String serviceType) {
+    List<PortCallPhaseTypeCode> typeCodes =
+        PortCallPhaseTypeCode.getCodesForPortCallServiceType(serviceType);
+    if (typeCodes.isEmpty()) {
+      return "";
+    }
+    return typeCodes.getFirst().name();
+  }
+}

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitPartyHelper.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitPartyHelper.java
@@ -210,15 +210,15 @@ public class JitPartyHelper {
           JitChecks.TIMESTAMP_ID, List.of(timestamp.get(JitChecks.TIMESTAMP_ID).asText()));
     }
     if (filters.contains(JitChecks.PORT_CALL_SERVICE_ID)) {
-      // The previous Planned timestamp has the same portCallServiceID.
-      JsonNode timestampNode = getTimestampBy(JitClassifierCode.PLN, null, timestampCalls);
+      // The previous Actual timestamp has the same portCallServiceID.
+      JsonNode timestampNode = getTimestampBy(JitClassifierCode.ACT, null, timestampCalls);
       queryParams.put(
           JitChecks.PORT_CALL_SERVICE_ID,
           List.of(timestampNode.get(JitChecks.PORT_CALL_SERVICE_ID).asText()));
     }
     if (filters.contains(JitChecks.CLASSIFIER_CODE)) {
-      // Filter by classifier code PLN.
-      JsonNode timestampNode = getTimestampBy(JitClassifierCode.PLN, null, timestampCalls);
+      // Filter by classifier code Actual.
+      JsonNode timestampNode = getTimestampBy(JitClassifierCode.ACT, null, timestampCalls);
       queryParams.put(
           JitChecks.CLASSIFIER_CODE,
           List.of(timestampNode.get(JitChecks.CLASSIFIER_CODE).asText()));
@@ -260,12 +260,13 @@ public class JitPartyHelper {
     return response;
   }
 
+  static void flushTimestamps(JsonNodeMap persistentMap) {
+    persistentMap.save(JitGetType.TIMESTAMPS.name(), OBJECT_MAPPER.createArrayNode());
+  }
+
   // Save the response for generating GET requests. Add it to the list of timestamps.
   static void storeTimestamp(JsonNodeMap persistentMap, JitTimestamp timestamp) {
     ArrayNode timestamps = (ArrayNode) persistentMap.load(JitGetType.TIMESTAMPS.name());
-    if (timestamps == null) {
-      timestamps = OBJECT_MAPPER.createArrayNode();
-    }
     ObjectNode timestampNode = timestamp.toJson();
     timestampNode.remove(JitProvider.IS_FYI);
     timestamps.add(timestampNode);

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitPartyHelper.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitPartyHelper.java
@@ -18,6 +18,7 @@ import org.dcsa.conformance.core.traffic.ConformanceMessageBody;
 import org.dcsa.conformance.core.traffic.ConformanceRequest;
 import org.dcsa.conformance.core.traffic.ConformanceResponse;
 import org.dcsa.conformance.standards.jit.model.JitGetPortCallFilters;
+import org.dcsa.conformance.standards.jit.model.JitGetPortServiceCallFilters;
 import org.dcsa.conformance.standards.jit.model.JitGetTerminalCallFilters;
 import org.dcsa.conformance.standards.jit.model.JitGetType;
 import org.dcsa.conformance.standards.jit.model.PortCallPhaseTypeCode;
@@ -43,6 +44,12 @@ public class JitPartyHelper {
       terminalCall.remove(JitProvider.IS_FYI);
       response.add(terminalCall);
       jitParty.addOperatorLogEntry("Handled GET Terminal Calls request accepted.");
+    } else if (request.url().contains(JitGetType.PORT_CALL_SERVICES.getUrlPath())) {
+      ObjectNode portServiceCall =
+          (ObjectNode) persistentMap.load(JitGetType.PORT_CALL_SERVICES.name());
+      portServiceCall.remove(JitProvider.IS_FYI);
+      response.add(portServiceCall);
+      jitParty.addOperatorLogEntry("Handled GET Port Service Calls request accepted.");
     } else {
       jitParty.addOperatorLogEntry("Unhandled GET request.");
     }
@@ -88,6 +95,22 @@ public class JitPartyHelper {
       String propertyName = JitGetTerminalCallFilters.props().get(i);
       if (filters.contains(propertyName)) {
         queryParams.put(propertyName, List.of(terminalCall.get(propertyName).asText()));
+      }
+    }
+  }
+
+  static void createParamsForPortServiceCall(
+      JsonNodeMap persistentMap,
+      JitGetType getType,
+      List<String> filters,
+      Map<String, List<String>> queryParams) {
+    if (getType != JitGetType.PORT_CALL_SERVICES) return;
+
+    JsonNode portServiceCall = persistentMap.load(JitGetType.PORT_CALL_SERVICES.name());
+    for (int i = 0; i < JitGetPortServiceCallFilters.props().size(); i++) {
+      String propertyName = JitGetPortServiceCallFilters.props().get(i);
+      if (filters.contains(propertyName)) {
+        queryParams.put(propertyName, List.of(portServiceCall.get(propertyName).asText()));
       }
     }
   }

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitPartyHelper.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitPartyHelper.java
@@ -50,6 +50,12 @@ public class JitPartyHelper {
       portServiceCall.remove(JitProvider.IS_FYI);
       response.add(portServiceCall);
       jitParty.addOperatorLogEntry("Handled GET Port Service Calls request accepted.");
+    } else if (request.url().contains(JitGetType.VESSEL_STATUSES.getUrlPath())) {
+      ObjectNode vesselStatusCall =
+          (ObjectNode) persistentMap.load(JitGetType.VESSEL_STATUSES.name());
+      vesselStatusCall.remove(JitProvider.IS_FYI);
+      response.add(vesselStatusCall);
+      jitParty.addOperatorLogEntry("Handled GET Vessel Status Calls request accepted.");
     } else {
       jitParty.addOperatorLogEntry("Unhandled GET request.");
     }
@@ -112,6 +118,20 @@ public class JitPartyHelper {
       if (filters.contains(propertyName)) {
         queryParams.put(propertyName, List.of(portServiceCall.get(propertyName).asText()));
       }
+    }
+  }
+
+  public static void createParamsForVesselStatusCall(
+      JsonNodeMap persistentMap,
+      JitGetType getType,
+      List<String> filters,
+      Map<String, List<String>> queryParams) {
+    if (getType != JitGetType.VESSEL_STATUSES) return;
+
+    JsonNode vesselStatus = persistentMap.load(JitGetType.VESSEL_STATUSES.name());
+    String propertyName = "portCallServiceID"; // Only one property exists for vessel status.
+    if (filters.contains(propertyName)) {
+      queryParams.put(propertyName, List.of(vesselStatus.get(propertyName).asText()));
     }
   }
 

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitProvider.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitProvider.java
@@ -143,6 +143,9 @@ public class JitProvider extends ConformanceParty {
 
     syncCounterpartPut(JitStandard.PORT_CALL_SERVICES_URL + dsp.portCallServiceID(), jsonBody);
 
+    persistentMap.save(
+      JitGetType.PORT_CALL_SERVICES.name(), jsonBody); // Save the response for generating GET requests.
+
     addOperatorLogEntry(
         "Submitted %s Port Call Service request with portCallServiceID: %s"
             .formatted(serviceType, dsp.portCallServiceID()));
@@ -274,6 +277,7 @@ public class JitProvider extends ConformanceParty {
     Map<String, List<String>> queryParams = new HashMap<>();
     JitPartyHelper.createParamsForPortCall(persistentMap, getType, filters, queryParams);
     JitPartyHelper.createParamsForTerminalCall(persistentMap, getType, filters, queryParams);
+    JitPartyHelper.createParamsForPortServiceCall(persistentMap, getType, filters, queryParams);
 
     syncCounterpartGet(getType.getUrlPath(), queryParams);
     addOperatorLogEntry(

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitProvider.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitProvider.java
@@ -159,6 +159,9 @@ public class JitProvider extends ConformanceParty {
     JsonNode jsonBody = JitPartyHelper.replacePlaceHolders("vessel-status", dsp);
     syncCounterpartPut(JitStandard.VESSEL_STATUS_URL + dsp.portCallServiceID(), jsonBody);
 
+    persistentMap.save(
+      JitGetType.VESSEL_STATUSES.name(), jsonBody); // Save the response for generating GET requests.
+
     addOperatorLogEntry(
         "Submitted Vessel Status for portCallServiceID: %s".formatted(dsp.portCallServiceID()));
   }
@@ -278,6 +281,7 @@ public class JitProvider extends ConformanceParty {
     JitPartyHelper.createParamsForPortCall(persistentMap, getType, filters, queryParams);
     JitPartyHelper.createParamsForTerminalCall(persistentMap, getType, filters, queryParams);
     JitPartyHelper.createParamsForPortServiceCall(persistentMap, getType, filters, queryParams);
+    JitPartyHelper.createParamsForVesselStatusCall(persistentMap, getType, filters, queryParams);
 
     syncCounterpartGet(getType.getUrlPath(), queryParams);
     addOperatorLogEntry(

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitProvider.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitProvider.java
@@ -98,6 +98,7 @@ public class JitProvider extends ConformanceParty {
 
     persistentMap.save(
         JitGetType.PORT_CALLS.name(), jsonBody); // Save the response for generating GET requests.
+    JitPartyHelper.flushTimestamps(persistentMap); // Prevent timestamps from being reused (if any).
 
     addOperatorLogEntry(
         "Submitted Port Call request for portCallID: %s".formatted(dsp.portCallID()));

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitProvider.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitProvider.java
@@ -115,7 +115,8 @@ public class JitProvider extends ConformanceParty {
     syncCounterpartPut(JitStandard.TERMINAL_CALL_URL + dsp.terminalCallID(), jsonBody);
 
     persistentMap.save(
-      JitGetType.TERMINAL_CALLS.name(), jsonBody); // Save the response for generating GET requests.
+        JitGetType.TERMINAL_CALLS.name(),
+        jsonBody); // Save the response for generating GET requests.
 
     addOperatorLogEntry(
         "Submitted Terminal Call request for portCallID: %s and TerminalCallId: %s "
@@ -144,7 +145,8 @@ public class JitProvider extends ConformanceParty {
     syncCounterpartPut(JitStandard.PORT_CALL_SERVICES_URL + dsp.portCallServiceID(), jsonBody);
 
     persistentMap.save(
-      JitGetType.PORT_CALL_SERVICES.name(), jsonBody); // Save the response for generating GET requests.
+        JitGetType.PORT_CALL_SERVICES.name(),
+        jsonBody); // Save the response for generating GET requests.
 
     addOperatorLogEntry(
         "Submitted %s Port Call Service request with portCallServiceID: %s"
@@ -160,7 +162,8 @@ public class JitProvider extends ConformanceParty {
     syncCounterpartPut(JitStandard.VESSEL_STATUS_URL + dsp.portCallServiceID(), jsonBody);
 
     persistentMap.save(
-      JitGetType.VESSEL_STATUSES.name(), jsonBody); // Save the response for generating GET requests.
+        JitGetType.VESSEL_STATUSES.name(),
+        jsonBody); // Save the response for generating GET requests.
 
     addOperatorLogEntry(
         "Submitted Vessel Status for portCallServiceID: %s".formatted(dsp.portCallServiceID()));
@@ -187,6 +190,8 @@ public class JitProvider extends ConformanceParty {
     JitTimestamp timestamp =
         JitTimestamp.getTimestampForType(timestampType, previousTimestamp, dsp.isFYI());
     sendTimestampPutRequest(timestampType, timestamp);
+
+    JitPartyHelper.storeTimestamp(persistentMap, timestamp);
   }
 
   private void outOfBandTimestampRequest(JsonNode actionPrompt) {
@@ -276,12 +281,14 @@ public class JitProvider extends ConformanceParty {
         "{}.sendGetActionRequest({})", getClass().getSimpleName(), actionPrompt.toPrettyString());
 
     JitGetType getType = JitGetType.valueOf(actionPrompt.required(JitGetAction.GET_TYPE).asText());
-    List<String> filters = OBJECT_MAPPER.convertValue(actionPrompt.get(JitGetAction.FILTERS), List.class);
+    List<String> filters =
+        OBJECT_MAPPER.convertValue(actionPrompt.get(JitGetAction.FILTERS), List.class);
     Map<String, List<String>> queryParams = new HashMap<>();
     JitPartyHelper.createParamsForPortCall(persistentMap, getType, filters, queryParams);
     JitPartyHelper.createParamsForTerminalCall(persistentMap, getType, filters, queryParams);
     JitPartyHelper.createParamsForPortServiceCall(persistentMap, getType, filters, queryParams);
     JitPartyHelper.createParamsForVesselStatusCall(persistentMap, getType, filters, queryParams);
+    JitPartyHelper.createParamsForTimestampCall(persistentMap, getType, filters, queryParams);
 
     syncCounterpartGet(getType.getUrlPath(), queryParams);
     addOperatorLogEntry(
@@ -317,6 +324,7 @@ public class JitProvider extends ConformanceParty {
                   JitTimestampType.fromClassifierCode(timestamp.classifierCode()),
                   timestamp.dateTime(),
                   timestamp.remark()));
+      JitPartyHelper.storeTimestamp(persistentMap, timestamp);
     } else {
       statusCode = 400;
       addOperatorLogEntry("Handled an unknown request, which is wrong.");

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitProvider.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitProvider.java
@@ -14,7 +14,6 @@ import org.dcsa.conformance.core.party.PartyConfiguration;
 import org.dcsa.conformance.core.party.PartyWebClient;
 import org.dcsa.conformance.core.scenario.ConformanceAction;
 import org.dcsa.conformance.core.state.JsonNodeMap;
-import org.dcsa.conformance.core.toolkit.JsonToolkit;
 import org.dcsa.conformance.core.traffic.ConformanceMessageBody;
 import org.dcsa.conformance.core.traffic.ConformanceRequest;
 import org.dcsa.conformance.core.traffic.ConformanceResponse;
@@ -22,6 +21,7 @@ import org.dcsa.conformance.standards.jit.JitStandard;
 import org.dcsa.conformance.standards.jit.action.JitAction;
 import org.dcsa.conformance.standards.jit.action.JitCancelAction;
 import org.dcsa.conformance.standards.jit.action.JitDeclineAction;
+import org.dcsa.conformance.standards.jit.action.JitGetAction;
 import org.dcsa.conformance.standards.jit.action.JitOOBTimestampAction;
 import org.dcsa.conformance.standards.jit.action.JitOmitPortCallAction;
 import org.dcsa.conformance.standards.jit.action.JitOmitTerminalCallAction;
@@ -30,10 +30,9 @@ import org.dcsa.conformance.standards.jit.action.JitPortCallServiceAction;
 import org.dcsa.conformance.standards.jit.action.JitTerminalCallAction;
 import org.dcsa.conformance.standards.jit.action.JitTimestampAction;
 import org.dcsa.conformance.standards.jit.action.JitVesselStatusAction;
+import org.dcsa.conformance.standards.jit.model.JitGetType;
 import org.dcsa.conformance.standards.jit.model.JitTimestamp;
 import org.dcsa.conformance.standards.jit.model.JitTimestampType;
-import org.dcsa.conformance.standards.jit.model.PortCallPhaseTypeCode;
-import org.dcsa.conformance.standards.jit.model.PortCallServiceEventTypeCode;
 import org.dcsa.conformance.standards.jit.model.PortCallServiceType;
 
 @Slf4j
@@ -85,7 +84,8 @@ public class JitProvider extends ConformanceParty {
         Map.entry(JitCancelAction.class, this::cancelCallRequest),
         Map.entry(JitDeclineAction.class, this::declineRequest),
         Map.entry(JitOmitPortCallAction.class, this::omitPortCallRequest),
-        Map.entry(JitOmitTerminalCallAction.class, this::omitTerminalCallRequest));
+        Map.entry(JitOmitTerminalCallAction.class, this::omitTerminalCallRequest),
+        Map.entry(JitGetAction.class, this::sendGetActionRequest));
   }
 
   private void portCallRequest(JsonNode actionPrompt) {
@@ -93,8 +93,11 @@ public class JitProvider extends ConformanceParty {
 
     DynamicScenarioParameters dsp =
         DynamicScenarioParameters.fromJson(actionPrompt.path(JitAction.DSP_TAG));
-    JsonNode jsonBody = replacePlaceHolders("port-call", dsp);
+    JsonNode jsonBody = JitPartyHelper.replacePlaceHolders("port-call", dsp);
     syncCounterpartPut(JitStandard.PORT_CALL_URL + dsp.portCallID(), jsonBody);
+
+    persistentMap.save(
+        JitGetType.PORT_CALLS.name(), jsonBody); // Save the portCall for generating GET requests.
 
     addOperatorLogEntry(
         "Submitted Port Call request for portCallID: %s".formatted(dsp.portCallID()));
@@ -108,7 +111,7 @@ public class JitProvider extends ConformanceParty {
     if (dsp.terminalCallID() == null) {
       dsp = dsp.withTerminalCallID(UUID.randomUUID().toString());
     }
-    JsonNode jsonBody = replacePlaceHolders("terminal-call", dsp);
+    JsonNode jsonBody = JitPartyHelper.replacePlaceHolders("terminal-call", dsp);
     syncCounterpartPut(JitStandard.TERMINAL_CALL_URL + dsp.terminalCallID(), jsonBody);
 
     addOperatorLogEntry(
@@ -128,7 +131,7 @@ public class JitProvider extends ConformanceParty {
       serviceType = dsp.portCallServiceType().name();
     }
     dsp = dsp.withPortCallServiceType(PortCallServiceType.fromName(serviceType));
-    JsonNode jsonBody = replacePlaceHolders("port-call-service", dsp);
+    JsonNode jsonBody = JitPartyHelper.replacePlaceHolders("port-call-service", dsp);
 
     // Only MOVES service type requires the Moves part of the request. Removing it from the others.
     if (dsp.portCallServiceType() != PortCallServiceType.MOVES) {
@@ -147,7 +150,7 @@ public class JitProvider extends ConformanceParty {
 
     DynamicScenarioParameters dsp =
         DynamicScenarioParameters.fromJson(actionPrompt.path(JitAction.DSP_TAG));
-    JsonNode jsonBody = replacePlaceHolders("vessel-status", dsp);
+    JsonNode jsonBody = JitPartyHelper.replacePlaceHolders("vessel-status", dsp);
     syncCounterpartPut(JitStandard.VESSEL_STATUS_URL + dsp.portCallServiceID(), jsonBody);
 
     addOperatorLogEntry(
@@ -259,6 +262,21 @@ public class JitProvider extends ConformanceParty {
     addOperatorLogEntry("Submitted Omit Terminal Call with ID: %s".formatted(dsp.terminalCallID()));
   }
 
+  void sendGetActionRequest(JsonNode actionPrompt) {
+    log.info(
+        "{}.sendGetActionRequest({})", getClass().getSimpleName(), actionPrompt.toPrettyString());
+
+    JitGetType getType = JitGetType.valueOf(actionPrompt.required(JitGetAction.GET_TYPE).asText());
+    List<String> filters = OBJECT_MAPPER.convertValue(actionPrompt.get(JitGetAction.FILTERS), List.class);
+    Map<String, List<String>> queryParams = new HashMap<>();
+    JitPartyHelper.createParamsForPortCall(persistentMap, getType, filters, queryParams);
+
+    syncCounterpartGet(getType.getUrlPath(), queryParams);
+    addOperatorLogEntry(
+        "Submitted GET %s request with URL parameters: %s."
+            .formatted(getType.getName(), queryParams));
+  }
+
   private void sendTimestampPutRequest(
       @NonNull JitTimestampType timestampType, @NonNull JitTimestamp timestamp) {
     syncCounterpartPut(JitStandard.TIMESTAMP_URL + timestamp.timestampID(), timestamp.toJson());
@@ -267,54 +285,12 @@ public class JitProvider extends ConformanceParty {
         "Submitted %s timestamp for: %s".formatted(timestampType, timestamp.dateTime()));
   }
 
-  private JsonNode replacePlaceHolders(String fileType, DynamicScenarioParameters dsp) {
-    PortCallServiceType serviceType = dsp.portCallServiceType();
-    String portCallPhaseTypeCode = "";
-    String portCallServiceEventTypeCode = "";
-    if (serviceType != null) {
-      portCallPhaseTypeCode = calculatePortCallPhaseTypeCode(serviceType.name());
-      portCallServiceEventTypeCode =
-          PortCallServiceEventTypeCode.getCodesForPortCallServiceType(serviceType.name())
-              .getFirst()
-              .name();
-    }
-
-    JsonNode jsonNode =
-        JsonToolkit.templateFileToJsonNode(
-            "/standards/jit/messages/jit-200-%s-request.json".formatted(fileType),
-            Map.of(
-                "PORT_CALL_ID_PLACEHOLDER",
-                Objects.requireNonNullElse(dsp.portCallID(), ""),
-                "TERMINAL_CALL_ID_PLACEHOLDER",
-                Objects.requireNonNullElse(dsp.terminalCallID(), ""),
-                "PORT_CALL_SERVICE_TYPE_PLACEHOLDER",
-                serviceType != null ? serviceType.name() : "",
-                "PORT_CALL_SERVICE_ID_PLACEHOLDER",
-                Objects.requireNonNullElse(dsp.portCallServiceID(), ""),
-                "PORT_CALL_SERVICE_EVENT_TYPE_CODE_PLACEHOLDER",
-                portCallServiceEventTypeCode,
-                "PORT_CALL_PHASE_TYPE_CODE_PLACEHOLDER",
-                portCallPhaseTypeCode,
-                "IS_FYI_PLACEHOLDER",
-                Boolean.toString(dsp.isFYI())));
-    // Some serviceType do not have a portCallPhaseTypeCode; remove it, since it is an enum.
-    if (serviceType != null && portCallPhaseTypeCode.isEmpty())
-      ((ObjectNode) jsonNode).remove("portCallPhaseTypeCode");
-    return jsonNode;
-  }
-
-  private static String calculatePortCallPhaseTypeCode(String serviceType) {
-    List<PortCallPhaseTypeCode> typeCodes =
-        PortCallPhaseTypeCode.getCodesForPortCallServiceType(serviceType);
-    if (typeCodes.isEmpty()) {
-      return "";
-    }
-    return typeCodes.getFirst().name();
-  }
-
   @Override
   public ConformanceResponse handleRequest(ConformanceRequest request) {
     log.info("{}.handleRequest() type: {}", getClass().getSimpleName(), request.method());
+    if (request.method().equals(JitStandard.GET)) {
+      return JitPartyHelper.handleGetRequest(request, persistentMap, apiVersion, this);
+    }
     int statusCode = 204;
     if (request.message().body().getJsonBody().isEmpty()) {
       addOperatorLogEntry("Handled an empty request, which is wrong.");

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitProvider.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitProvider.java
@@ -97,7 +97,7 @@ public class JitProvider extends ConformanceParty {
     syncCounterpartPut(JitStandard.PORT_CALL_URL + dsp.portCallID(), jsonBody);
 
     persistentMap.save(
-        JitGetType.PORT_CALLS.name(), jsonBody); // Save the portCall for generating GET requests.
+        JitGetType.PORT_CALLS.name(), jsonBody); // Save the response for generating GET requests.
 
     addOperatorLogEntry(
         "Submitted Port Call request for portCallID: %s".formatted(dsp.portCallID()));
@@ -113,6 +113,9 @@ public class JitProvider extends ConformanceParty {
     }
     JsonNode jsonBody = JitPartyHelper.replacePlaceHolders("terminal-call", dsp);
     syncCounterpartPut(JitStandard.TERMINAL_CALL_URL + dsp.terminalCallID(), jsonBody);
+
+    persistentMap.save(
+      JitGetType.TERMINAL_CALLS.name(), jsonBody); // Save the response for generating GET requests.
 
     addOperatorLogEntry(
         "Submitted Terminal Call request for portCallID: %s and TerminalCallId: %s "
@@ -270,6 +273,7 @@ public class JitProvider extends ConformanceParty {
     List<String> filters = OBJECT_MAPPER.convertValue(actionPrompt.get(JitGetAction.FILTERS), List.class);
     Map<String, List<String>> queryParams = new HashMap<>();
     JitPartyHelper.createParamsForPortCall(persistentMap, getType, filters, queryParams);
+    JitPartyHelper.createParamsForTerminalCall(persistentMap, getType, filters, queryParams);
 
     syncCounterpartGet(getType.getUrlPath(), queryParams);
     addOperatorLogEntry(

--- a/jit/src/main/resources/standards/jit/messages/jit-200-port-call-service-request.json
+++ b/jit/src/main/resources/standards/jit/messages/jit-200-port-call-service-request.json
@@ -46,7 +46,7 @@
       },
       "carrierCode": "MAEU",
       "carrierCodeListProvider": "NMFTA",
-      "restowMoves": 20
+      "restowMoves": 155
     }
   ],
   "isFYI": IS_FYI_PLACEHOLDER

--- a/jit/src/main/resources/standards/jit/schemas/JIT_v2.0.0.yaml
+++ b/jit/src/main/resources/standards/jit/schemas/JIT_v2.0.0.yaml
@@ -135,7 +135,7 @@ paths:
                 summary: |
                   Send a FYI to a consumer
                 description: |
-                  A **Port Call** has already been created - now send the **Port Call** as a FYI to a (secondary) consumer. In this example all properties are the same as the example above.
+                  A **Port Call** has already been created - now send the **Port Call** as a FYI to a (secondary) consumer. In this example all properties are the same as the previous example, except for `isFYI`.
                 value:
                   portCallID: '0342254a-5927-4856-b9c9-aa12e7c00563'
                   UNLocationCode: 'NLAMS'
@@ -2763,8 +2763,12 @@ components:
         The **Classifier Code** to filter by. Specifying this filter will ensure that the result set contains only objects where the `classifierCode` property is present and its value matches one of the values of the corresponding filter query parameter.
       schema:
         type: string
-        format: uuid
-        example: 0342254a-5927-4856-b9c9-aa12e7c00563
+        enum:
+          - ACT
+          - EST
+          - PLN
+          - REQ
+        example: 'ACT'
     
     #############
     # Path params


### PR DESCRIPTION
All JIT 2.0 GET actions are covered now. But it is not checked yet if the results are okay, returned from the endpoint (like matching IDs, matching result count etc). There are still 2 issues left in Jira, where I can put that into.  

Since the `persistentMap` is not clean when every scenario starts, `flushTimestamps` is called on the SSPAction & PortCall Action. Need to fix that in a different way later. 