### PR TITLE
SD-2029 JIT 2.0: Add Inline Instructions

### DIFF
--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/action/Carrier_SupplyScenarioParametersAction.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/action/Carrier_SupplyScenarioParametersAction.java
@@ -2,11 +2,9 @@ package org.dcsa.conformance.standards.booking.action;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.util.Collections;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import lombok.NonNull;
-import org.dcsa.conformance.core.toolkit.IOToolkit;
 import org.dcsa.conformance.standards.booking.checks.ScenarioType;
 import org.dcsa.conformance.standards.booking.party.BookingCarrier;
 import org.dcsa.conformance.standards.booking.party.CarrierScenarioParameters;

--- a/core/src/main/java/org/dcsa/conformance/core/toolkit/JsonToolkit.java
+++ b/core/src/main/java/org/dcsa/conformance/core/toolkit/JsonToolkit.java
@@ -4,10 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.StreamSupport;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
@@ -58,7 +56,7 @@ public class JsonToolkit {
 
   public static Map<String, ? extends Collection<String>> mapOfStringToStringCollectionFromJson(
       ArrayNode arrayNode) {
-    HashMap<String, Collection<String>> map = new HashMap<>();
+    Map<String, Collection<String>> map = new HashMap<>();
     StreamSupport.stream(arrayNode.spliterator(), false)
         .forEach(
             entryNode ->

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/JitScenarioListBuilder.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/JitScenarioListBuilder.java
@@ -1272,14 +1272,14 @@ class JitScenarioListBuilder extends ScenarioListBuilder<JitScenarioListBuilder>
 
   private static JitScenarioListBuilder serviceCall(
       JitScenarioContext context,
-      PortCallServiceTypeCode serviceType,
+      PortCallServiceTypeCode serviceTypeCode,
       JitServiceTypeSelector selector) {
-    if (serviceType == null && selector == null) {
-      throw new IllegalArgumentException("Either serviceType or selector must be provided");
+    if (serviceTypeCode == null && selector == null) {
+      throw new IllegalArgumentException("Either serviceTypeCode or selector must be provided");
     }
     return new JitScenarioListBuilder(
         previousAction ->
-            new JitPortCallServiceAction(context, previousAction, serviceType, selector));
+            new JitPortCallServiceAction(context, previousAction, serviceTypeCode, selector));
   }
 
   private static JitScenarioListBuilder vesselStatus(JitScenarioContext context) {

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitAction.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.dcsa.conformance.core.scenario.ConformanceAction;
+import org.dcsa.conformance.core.toolkit.IOToolkit;
 import org.dcsa.conformance.standards.jit.party.DynamicScenarioParameters;
 
 @Slf4j
@@ -58,5 +59,9 @@ public abstract class JitAction extends ConformanceAction {
     if (dspNode != null) {
       dsp = DynamicScenarioParameters.fromJson(dspNode);
     }
+  }
+
+  protected String getMarkdownFile(String fileName) {
+    return IOToolkit.templateFileToText("/standards/jit/instructions/" + fileName, null);
   }
 }

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitAction.java
@@ -2,6 +2,7 @@ package org.dcsa.conformance.standards.jit.action;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Map;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.dcsa.conformance.core.scenario.ConformanceAction;
@@ -62,6 +63,10 @@ public abstract class JitAction extends ConformanceAction {
   }
 
   protected String getMarkdownFile(String fileName) {
-    return IOToolkit.templateFileToText("/standards/jit/instructions/" + fileName, null);
+    return getMarkdownFile(fileName, null);
+  }
+
+  protected String getMarkdownFile(String fileName, Map<String, String> replacements) {
+    return IOToolkit.templateFileToText("/standards/jit/instructions/" + fileName, replacements);
   }
 }

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitCancelAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitCancelAction.java
@@ -28,7 +28,7 @@ public class JitCancelAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return getMarkdownFile("prompt-send-cancel.md").formatted(getActionTitle());
+    return getMarkdownFile("prompt-send-cancel.md");
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitCancelAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitCancelAction.java
@@ -28,7 +28,7 @@ public class JitCancelAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return "Send a %s (POST) request".formatted(getActionTitle());
+    return getMarkdownFile("prompt-send-cancel.md").formatted(getActionTitle());
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitDeclineAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitDeclineAction.java
@@ -29,7 +29,7 @@ public class JitDeclineAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return "Send a %s (POST) request".formatted(getActionTitle());
+    return getMarkdownFile("prompt-send-decline.md").formatted(getActionTitle());
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitDeclineAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitDeclineAction.java
@@ -29,7 +29,7 @@ public class JitDeclineAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return getMarkdownFile("prompt-send-decline.md").formatted(getActionTitle());
+    return getMarkdownFile("prompt-send-decline.md");
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitGetAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitGetAction.java
@@ -2,6 +2,7 @@ package org.dcsa.conformance.standards.jit.action;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
@@ -89,7 +90,8 @@ public class JitGetAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return getMarkdownFile("prompt-get-request.md").formatted(getType, getType);
+    return getMarkdownFile(
+        "prompt-get-request.md", Map.of("GET_TYPE_PLACEHOLDER", getType.getName()));
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitGetAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitGetAction.java
@@ -89,7 +89,7 @@ public class JitGetAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return "Get %s (GET) request".formatted(getType);
+    return getMarkdownFile("prompt-get-request.md").formatted(getType, getType);
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitOOBTimestampAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitOOBTimestampAction.java
@@ -28,8 +28,7 @@ public class JitOOBTimestampAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return ("Process and accept an Out-of-Band request for a %s timestamp"
-        .formatted(timestampType));
+    return getMarkdownFile("prompt-process-oob-request.md").formatted(timestampType);
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitOOBTimestampAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitOOBTimestampAction.java
@@ -1,6 +1,7 @@
 package org.dcsa.conformance.standards.jit.action;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.dcsa.conformance.core.scenario.ConformanceAction;
 import org.dcsa.conformance.standards.jit.JitScenarioContext;
@@ -28,7 +29,9 @@ public class JitOOBTimestampAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return getMarkdownFile("prompt-process-oob-request.md").formatted(timestampType);
+    return getMarkdownFile(
+        "prompt-process-oob-request.md",
+        Map.of("TIMESTAMP_TYPE_PLACEHOLDER", timestampType.name()));
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitOOBTimestampInputAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitOOBTimestampInputAction.java
@@ -4,6 +4,7 @@ import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.dcsa.conformance.core.scenario.ConformanceAction;
 import org.dcsa.conformance.standards.jit.JitScenarioContext;
@@ -36,7 +37,8 @@ public class JitOOBTimestampInputAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return getMarkdownFile("prompt-process-oob-input.md").formatted(timestampType);
+    return getMarkdownFile(
+        "prompt-process-oob-input.md", Map.of("TIMESTAMP_TYPE_PLACEHOLDER", timestampType.name()));
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitOOBTimestampInputAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitOOBTimestampInputAction.java
@@ -36,8 +36,7 @@ public class JitOOBTimestampInputAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return ("Supply the out-of-band %s timestamp that you (could) have received out-of-band from the service provider, using the format below:"
-        .formatted(timestampType));
+    return getMarkdownFile("prompt-process-oob-input.md").formatted(timestampType);
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitOmitPortCallAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitOmitPortCallAction.java
@@ -25,7 +25,7 @@ public class JitOmitPortCallAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return getMarkdownFile("prompt-send-omit-port-call.md").formatted(getActionTitle());
+    return getMarkdownFile("prompt-send-omit-port-call.md");
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitOmitPortCallAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitOmitPortCallAction.java
@@ -25,7 +25,7 @@ public class JitOmitPortCallAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return "Send an %s (POST) request".formatted(getActionTitle());
+    return getMarkdownFile("prompt-send-omit-port-call.md").formatted(getActionTitle());
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitOmitTerminalCallAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitOmitTerminalCallAction.java
@@ -28,7 +28,7 @@ public class JitOmitTerminalCallAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return "Send an %s (POST) request".formatted(getActionTitle());
+    return getMarkdownFile("prompt-send-omit-terminal-call.md").formatted(getActionTitle());
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitOmitTerminalCallAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitOmitTerminalCallAction.java
@@ -28,7 +28,7 @@ public class JitOmitTerminalCallAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return getMarkdownFile("prompt-send-omit-terminal-call.md").formatted(getActionTitle());
+    return getMarkdownFile("prompt-send-omit-terminal-call.md");
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitPortCallAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitPortCallAction.java
@@ -50,7 +50,7 @@ public class JitPortCallAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return "Send a Port Call (PUT)";
+    return getMarkdownFile("prompt-send-port-call.md");
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitPortCallServiceAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitPortCallServiceAction.java
@@ -2,6 +2,7 @@ package org.dcsa.conformance.standards.jit.action;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Map;
 import java.util.stream.Stream;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
@@ -79,7 +80,7 @@ public class JitPortCallServiceAction extends JitAction {
   @Override
   public String getHumanReadablePrompt() {
     if (dsp == null) dsp = ((JitAction) previousAction).getDsp();
-    String replacement =
+    String typeOfServiceText =
         switch (dsp.selector()) {
           case FULL_ERP, S_A_PATTERN:
             yield "the %s".formatted(dsp.selector().getFullName());
@@ -88,7 +89,8 @@ public class JitPortCallServiceAction extends JitAction {
           case ANY:
             yield "a service you supply";
         };
-    return getMarkdownFile("prompt-send-port-call-service.md").formatted(replacement);
+    return getMarkdownFile(
+        "prompt-send-port-call-service.md", Map.of("SERVICE_TYPE_PLACEHOLDER", typeOfServiceText));
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitPortCallServiceAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitPortCallServiceAction.java
@@ -20,7 +20,7 @@ import org.dcsa.conformance.standards.jit.party.JitRole;
 @Slf4j
 @ToString
 public class JitPortCallServiceAction extends JitAction {
-  public static final String SERVICE_TYPE = "serviceType";
+  public static final String SERVICE_TYPE = "serviceTypeCode";
 
   private final JsonSchemaValidator validator;
   private final PortCallServiceTypeCode serviceType;
@@ -79,14 +79,16 @@ public class JitPortCallServiceAction extends JitAction {
   @Override
   public String getHumanReadablePrompt() {
     if (dsp == null) dsp = ((JitAction) previousAction).getDsp();
-    return switch (dsp.selector()) {
-      case FULL_ERP, S_A_PATTERN:
-        yield "Send a Port Call Service (PUT) for the %s".formatted(dsp.selector().getFullName());
-      case GIVEN:
-        yield "Send a Port Call Service (PUT) for %s".formatted(serviceType.name());
-      case ANY:
-        yield "Send a Port Call Service (PUT) for a service you supply";
-    };
+    String replacement =
+        switch (dsp.selector()) {
+          case FULL_ERP, S_A_PATTERN:
+            yield "the %s".formatted(dsp.selector().getFullName());
+          case GIVEN:
+            yield "%s".formatted(serviceType.name());
+          case ANY:
+            yield "a service you supply";
+        };
+    return getMarkdownFile("prompt-send-port-call-service.md").formatted(replacement);
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitTerminalCallAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitTerminalCallAction.java
@@ -44,7 +44,7 @@ public class JitTerminalCallAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return "Send a Terminal Call (PUT)";
+    return getMarkdownFile("prompt-send-terminal-call.md");
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitTimestampAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitTimestampAction.java
@@ -67,7 +67,7 @@ public class JitTimestampAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return "Send %s timestamp (PUT) call".formatted(timestampType);
+    return getMarkdownFile("prompt-send-timestamp.md").formatted(timestampType.name());
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitTimestampAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitTimestampAction.java
@@ -2,6 +2,7 @@ package org.dcsa.conformance.standards.jit.action;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Map;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.dcsa.conformance.core.check.ApiHeaderCheck;
@@ -67,7 +68,8 @@ public class JitTimestampAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return getMarkdownFile("prompt-send-timestamp.md").formatted(timestampType.name());
+    return getMarkdownFile(
+        "prompt-send-timestamp.md", Map.of("TIMESTAMP_TYPE_PLACEHOLDER", timestampType.name()));
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitVesselStatusAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitVesselStatusAction.java
@@ -26,7 +26,7 @@ public class JitVesselStatusAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return "Send a Vessel Status (PUT)";
+    return getMarkdownFile("prompt-send-vessel-status.md");
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/SupplyScenarioParametersAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/SupplyScenarioParametersAction.java
@@ -49,7 +49,7 @@ public class SupplyScenarioParametersAction extends JitAction {
 
   @Override
   public String getHumanReadablePrompt() {
-    return "Supply the parameters required by the scenario:";
+    return getMarkdownFile("prompt-csp.md");
   }
 
   @Override
@@ -72,7 +72,7 @@ public class SupplyScenarioParametersAction extends JitAction {
         new DynamicScenarioParameters(
             null,
             null,
-            suppliedScenarioParameters.serviceType(),
+            suppliedScenarioParameters.serviceTypeCode(),
             suppliedScenarioParameters.portCallID(),
             suppliedScenarioParameters.terminalCallID(),
             suppliedScenarioParameters.portCallServiceID(),

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitPartyHelper.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitPartyHelper.java
@@ -278,18 +278,17 @@ public class JitPartyHelper {
     timestampNode.remove(JitProvider.IS_FYI);
     timestamps.add(timestampNode);
     persistentMap.save(JitGetType.TIMESTAMPS.name(), timestamps);
-    // TODO: deal with previous received timestamps with the same type.
   }
 
   public static ObjectNode getFileWithReplacedPlaceHolders(
       String fileType, DynamicScenarioParameters dsp) {
-    PortCallServiceTypeCode serviceType = dsp.portCallServiceTypeCode();
+    PortCallServiceTypeCode serviceTypeCode = dsp.portCallServiceTypeCode();
     String portCallPhaseTypeCode = "";
     String portCallServiceEventTypeCode = "";
-    if (serviceType != null) {
-      portCallPhaseTypeCode = calculatePortCallPhaseTypeCode(serviceType.name());
+    if (serviceTypeCode != null) {
+      portCallPhaseTypeCode = calculatePortCallPhaseTypeCode(serviceTypeCode.name());
       portCallServiceEventTypeCode =
-          PortCallServiceEventTypeCode.getCodesForPortCallServiceTypeCode(serviceType.name())
+          PortCallServiceEventTypeCode.getCodesForPortCallServiceTypeCode(serviceTypeCode.name())
               .getFirst()
               .name();
     }
@@ -304,7 +303,7 @@ public class JitPartyHelper {
                     "TERMINAL_CALL_ID_PLACEHOLDER",
                     Objects.requireNonNullElse(dsp.terminalCallID(), ""),
                     "PORT_CALL_SERVICE_TYPE_CODE_PLACEHOLDER",
-                    serviceType != null ? serviceType.name() : "",
+                    serviceTypeCode != null ? serviceTypeCode.name() : "",
                     "PORT_CALL_SERVICE_ID_PLACEHOLDER",
                     Objects.requireNonNullElse(dsp.portCallServiceID(), ""),
                     "PORT_CALL_SERVICE_EVENT_TYPE_CODE_PLACEHOLDER",
@@ -313,8 +312,8 @@ public class JitPartyHelper {
                     portCallPhaseTypeCode,
                     "IS_FYI_PLACEHOLDER",
                     Boolean.toString(dsp.isFYI())));
-    // Some serviceType do not have a portCallPhaseTypeCode; remove it, since it is an enum.
-    if (serviceType != null && portCallPhaseTypeCode.isEmpty())
+    // Some serviceTypeCode do not have a portCallPhaseTypeCode; remove it, since it is an enum.
+    if (serviceTypeCode != null && portCallPhaseTypeCode.isEmpty())
       node.remove("portCallPhaseTypeCode");
 
     // Only MOVES service type requires the Moves part of the request. Removing it from other types.

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/SuppliedScenarioParameters.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/SuppliedScenarioParameters.java
@@ -12,7 +12,7 @@ public record SuppliedScenarioParameters(
     String portCallID,
     String terminalCallID,
     String portCallServiceID,
-    PortCallServiceTypeCode serviceType)
+    PortCallServiceTypeCode serviceTypeCode)
     implements ScenarioParameters {
 
   public static SuppliedScenarioParameters fromJson(JsonNode jsonNode) {

--- a/jit/src/main/resources/standards/jit/instructions/prompt-csp.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-csp.md
@@ -12,5 +12,5 @@ The synthetic provider uses the following parameters:
 * `serviceTypeCode` (optional): Only use this attribute when it is displayed below. Copied into the
   `/portCallServiceTypeCode` attribute of the Port Call Service request.
 
-Provide the scenario parameters in JSON format, optionally adjusting the value of each parameter as needed, so that
-your application can complete the scenario successfully. If the defaults are fine, just press `Submit`.
+Below you find the scenario parameters in JSON format. Optionally, adjust the values as needed, so that your application
+can complete the scenario successfully. If the defaults are fine, just press `Submit`.

--- a/jit/src/main/resources/standards/jit/instructions/prompt-csp.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-csp.md
@@ -1,8 +1,8 @@
-In this screen, you can influence the data what the synthetic provider will send to you. At the beginning of the
-scenario, you need to provide a number of parameters, which the provider will use to customize the requests and
+In this screen, you can influence the data what the synthetic service provider will send to you. At the beginning of the
+scenario, you need to provide a number of parameters, which the service provider will use to customize the requests and
 responses that it sends to your endpoint throughout the scenario.
 
-The synthetic provider uses the following parameters:
+The synthetic service provider uses the following parameters:
 
 * `portCallID` (mandatory): Copied into the `/portCallID` attribute of the Port Call and Terminal Call request.
 * `terminalCallID` (mandatory): Copied into the `/terminalCallID` attribute of both the Terminal Call and the Port Call

--- a/jit/src/main/resources/standards/jit/instructions/prompt-csp.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-csp.md
@@ -1,0 +1,16 @@
+In this screen, you can influence the data what the synthetic provider will send to you. At the beginning of the
+scenario, you need to provide a number of parameters, which the provider will use to customize the requests and
+responses that it sends to your endpoint throughout the scenario.
+
+The synthetic provider uses the following parameters:
+
+* `portCallID` (mandatory): Copied into the `/portCallID` attribute of the Port Call and Terminal Call request.
+* `terminalCallID` (mandatory): Copied into the `/terminalCallID` attribute of both the Terminal Call and the Port Call
+  Service request.
+* `portCallServiceID` (mandatory): Copied into the `/portCallServiceID` attribute of both the Port Call Service request
+  and Vessel Status request.
+* `serviceTypeCode` (optional): Only use this attribute when it is displayed below. Copied into the
+  `/portCallServiceTypeCode` attribute of the Port Call Service request.
+
+Provide the scenario parameters in JSON format, optionally adjusting the value of each parameter as needed, so that
+your application can complete the scenario successfully. If the defaults are fine, just press `Submit`.

--- a/jit/src/main/resources/standards/jit/instructions/prompt-get-request.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-get-request.md
@@ -1,2 +1,3 @@
-Get %s (GET) request. Retrieves a list of %s that match the specified filter criteria(s). Please look at the JIT schema
-for the list of available URL filter criteria(s) and to see which are mandatory to apply.
+Get GET_TYPE_PLACEHOLDER (GET) request. Retrieves a list of GET_TYPE_PLACEHOLDER that match the specified filter
+criteria(s). Please look at the action title or JIT schema for the list of available URL filter criteria(s) and to see
+which are mandatory to apply.

--- a/jit/src/main/resources/standards/jit/instructions/prompt-get-request.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-get-request.md
@@ -1,0 +1,2 @@
+Get %s (GET) request. Retrieves a list of %s that match the specified filter criteria(s). Please look at the JIT schema
+for the list of available URL filter criteria(s) and to see which are mandatory to apply.

--- a/jit/src/main/resources/standards/jit/instructions/prompt-process-oob-input.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-process-oob-input.md
@@ -1,2 +1,2 @@
-Supply the out-of-band %s timestamp that you (could) have received out-of-band from the service provider, using the
-format below:
+Adjust and submit the out-of-band TIMESTAMP_TYPE_PLACEHOLDER timestamp that you (could) have received out-of-band from
+the service provider:

--- a/jit/src/main/resources/standards/jit/instructions/prompt-process-oob-input.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-process-oob-input.md
@@ -1,0 +1,2 @@
+Supply the out-of-band %s timestamp that you (could) have received out-of-band from the service provider, using the
+format below:

--- a/jit/src/main/resources/standards/jit/instructions/prompt-process-oob-request.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-process-oob-request.md
@@ -1,0 +1,1 @@
+Process and accept an Out-of-Band request for a %s timestamp

--- a/jit/src/main/resources/standards/jit/instructions/prompt-process-oob-request.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-process-oob-request.md
@@ -1,1 +1,1 @@
-Process and accept an Out-of-Band request for a %s timestamp
+Process and accept an Out-of-Band request for a TIMESTAMP_TYPE_PLACEHOLDER timestamp.

--- a/jit/src/main/resources/standards/jit/instructions/prompt-send-cancel.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-send-cancel.md
@@ -1,0 +1,5 @@
+Send a %s (POST) request. Allows the provider to CANCEL a Port Call Service, signaling that the Port Call Service is no
+longer going to happen.
+
+* In the path, you must use the `portCallServiceID` (UUIDv4), which identifies the Port Call Service to cancel.
+* In the message body, optionally: You can provide a `reason` for the cancellation.

--- a/jit/src/main/resources/standards/jit/instructions/prompt-send-cancel.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-send-cancel.md
@@ -1,5 +1,5 @@
-Send a %s (POST) request. Allows the provider to CANCEL a Port Call Service, signaling that the Port Call Service is no
-longer going to happen.
+Send a Cancel Port Call Service (POST) request, signaling that the Port Call Service is no longer going to happen.
 
 * In the path, you must use the `portCallServiceID` (UUIDv4), which identifies the Port Call Service to cancel.
-* In the message body, optionally: You can provide a `reason` for the cancellation.
+* In the message body, optionally you can provide a `reason` for the cancellation. That explains why the Port Call
+  Service is being canceled.

--- a/jit/src/main/resources/standards/jit/instructions/prompt-send-decline.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-send-decline.md
@@ -1,5 +1,5 @@
-Send a %s (POST) request. Allows the consumer to DECLINE a Port Call Service, signaling that the Port Call Service is no
-longer going to happen.
+Send a Decline Port Call Service (POST) request, signaling that the Port Call Service is no longer going to happen.
 
 * In the path, you must use a `portCallServiceID` (UUIDv4), which identifies the Port Call Service to decline.
-* In the message body, optionally: You can provide a `reason` for the cancellation.
+* In the message body, optionally: You can provide a `reason` for the decline. That explains why the Port Call Service
+  is being declined.

--- a/jit/src/main/resources/standards/jit/instructions/prompt-send-decline.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-send-decline.md
@@ -1,0 +1,5 @@
+Send a %s (POST) request. Allows the consumer to DECLINE a Port Call Service, signaling that the Port Call Service is no
+longer going to happen.
+
+* In the path, you must use a `portCallServiceID` (UUIDv4), which identifies the Port Call Service to decline.
+* In the message body, optionally: You can provide a `reason` for the cancellation.

--- a/jit/src/main/resources/standards/jit/instructions/prompt-send-omit-port-call.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-send-omit-port-call.md
@@ -1,2 +1,1 @@
-Send an %s (POST) request. Allows the provider to OMIT a Port Call, signaling that the Port Call is no longer going to
-happen.
+Send an Omit Port Call (POST) request, signaling that the Port Call is no longer going to happen.

--- a/jit/src/main/resources/standards/jit/instructions/prompt-send-omit-port-call.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-send-omit-port-call.md
@@ -1,0 +1,2 @@
+Send an %s (POST) request. Allows the provider to OMIT a Port Call, signaling that the Port Call is no longer going to
+happen.

--- a/jit/src/main/resources/standards/jit/instructions/prompt-send-omit-terminal-call.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-send-omit-terminal-call.md
@@ -1,2 +1,1 @@
-Send an %s (POST) request. This allows the provider to OMIT a Terminal Call, signaling that the Terminal Call is no
-longer going to happen.
+Send an Omit Terminal Call (POST) request, signaling that the Terminal Call is no longer going to happen.

--- a/jit/src/main/resources/standards/jit/instructions/prompt-send-omit-terminal-call.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-send-omit-terminal-call.md
@@ -1,0 +1,2 @@
+Send an %s (POST) request. This allows the provider to OMIT a Terminal Call, signaling that the Terminal Call is no
+longer going to happen.

--- a/jit/src/main/resources/standards/jit/instructions/prompt-send-port-call-service.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-send-port-call-service.md
@@ -1,0 +1,9 @@
+Send a Port Call Service (PUT) for %s.
+
+* You must provide a unique `portCallServiceID` (UUIDv4), which identifies the Port Call Service.
+* The `portCallServiceID` must remain consistent across all subsequent communications and linked Timestamps.
+* The Port Call Service includes:
+  * link to the Terminal Call (required): `terminalCallID`
+  * type of Service (required): `portCallServiceTypeCode` and `portCallServiceEventTypeCode` (and optionally
+    `portCallPhaseTypeCode` and `facilityTypeCode`)
+  * a location (required): `portCallServiceLocation`

--- a/jit/src/main/resources/standards/jit/instructions/prompt-send-port-call-service.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-send-port-call-service.md
@@ -1,4 +1,4 @@
-Send a Port Call Service (PUT) for %s.
+Send a Port Call Service (PUT) for SERVICE_TYPE_PLACEHOLDER.
 
 * You must provide a unique `portCallServiceID` (UUIDv4), which identifies the Port Call Service.
 * The `portCallServiceID` must remain consistent across all subsequent communications and linked Timestamps.

--- a/jit/src/main/resources/standards/jit/instructions/prompt-send-port-call.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-send-port-call.md
@@ -1,0 +1,8 @@
+Send a Port Call (PUT) request.
+
+* You must provide a unique `portCallID` (UUIDv4), which identifies the Port Call.
+* The `portCallID` must remain consistent across all subsequent communications and linked Terminal Calls.
+* The Port Call includes:
+  * Location information (required): `UNLocationCode`
+  * static Vessel information (required): `vessel`
+  * an optional business identifier for the port visit: `portVisitReference`

--- a/jit/src/main/resources/standards/jit/instructions/prompt-send-terminal-call.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-send-terminal-call.md
@@ -1,0 +1,11 @@
+Send a Terminal Call (PUT) request.
+
+* You must provide a unique `terminalCallID` (UUIDv4), which identifies the Terminal Call.
+* The `terminalCallID` must remain consistent across all subsequent communications and linked Port Call Services.
+* The Terminal Call includes:
+  * link to the Port Call (required): `portCallID`
+  * Service information (required): `carrierServiceCode`, `carrierServiceName` (and an optional
+    `universalServiceReference`)
+  * Optionally: Voyage information: `carrierImportVoyageNumber`, `carrierExportVoyageNumber`,
+    `universalImportVoyageReference` and `universalExportVoyageReference`
+  * Optionally: Terminal information: `terminalCallReference` and `terminalCallSequenceNumber`

--- a/jit/src/main/resources/standards/jit/instructions/prompt-send-timestamp.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-send-timestamp.md
@@ -1,13 +1,13 @@
-Send a %s timestamp (PUT) call.
+Send a(n) TIMESTAMP_TYPE_PLACEHOLDER timestamp (PUT) call.
 You must provide a unique `timestampID` (UUIDv4), which identifies the Timestamp. If updating an existing Timestamp,
 e.g. updating the `delayReasonCode`, the provided `timestampID` must match the existing record.
 
-The Timestamp includes:
+The Timestamp includes a:
 
 * link to the Port Call Service (required): `portCallServiceID`
 * link to the Timestamp it replies to (in case it is not the initial Timestamp): `replyToTimestampID`
-* an ERP-A classification (required): `classifierCode`
+* ERP-A classification (required): `classifierCode`
 * dateTime of the Timestamp (required): `dateTime`
-* an updated location (optional only with REQuested Timestamp): `portCallServiceLocation`
-* Optionally: Timestamp information: `delayReasonCode` and `remark`
+* updated location (optional only with REQuested Timestamp): `portCallServiceLocation`
+* optional Timestamp information: `delayReasonCode` and `remark`
 

--- a/jit/src/main/resources/standards/jit/instructions/prompt-send-timestamp.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-send-timestamp.md
@@ -1,0 +1,13 @@
+Send a %s timestamp (PUT) call.
+You must provide a unique `timestampID` (UUIDv4), which identifies the Timestamp. If updating an existing Timestamp,
+e.g. updating the `delayReasonCode`, the provided `timestampID` must match the existing record.
+
+The Timestamp includes:
+
+* link to the Port Call Service (required): `portCallServiceID`
+* link to the Timestamp it replies to (in case it is not the initial Timestamp): `replyToTimestampID`
+* an ERP-A classification (required): `classifierCode`
+* dateTime of the Timestamp (required): `dateTime`
+* an updated location (optional only with REQuested Timestamp): `portCallServiceLocation`
+* Optionally: Timestamp information: `delayReasonCode` and `remark`
+

--- a/jit/src/main/resources/standards/jit/instructions/prompt-send-vessel-status.md
+++ b/jit/src/main/resources/standards/jit/instructions/prompt-send-vessel-status.md
@@ -1,0 +1,5 @@
+Send a Vessel Status (dynamic Vessel information) (PUT) call. This includes:
+
+* a link to the Port Call Service (required): `portCallServiceID` (UUIDv4).
+* Optionally: dynamic information about a Vessel: `draft`, `airDraft`, `aftDraft`, `forwardDraft`, `vesselPosition` and
+  `milesToDestinationPort`.

--- a/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/PintComponentFactory.java
+++ b/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/PintComponentFactory.java
@@ -10,7 +10,6 @@ import org.dcsa.conformance.core.party.PartyConfiguration;
 import org.dcsa.conformance.core.party.PartyWebClient;
 import org.dcsa.conformance.core.scenario.ScenarioListBuilder;
 import org.dcsa.conformance.core.state.JsonNodeMap;
-import org.dcsa.conformance.standards.ebl.crypto.PayloadSignerFactory;
 import org.dcsa.conformance.standards.eblinterop.party.PintReceivingPlatform;
 import org.dcsa.conformance.standards.eblinterop.party.PintRole;
 import org.dcsa.conformance.standards.eblinterop.party.PintSendingPlatform;


### PR DESCRIPTION
* Rename serviceType to serviceTypeCode (forgot some instances before)
* Remove unused imports

FYI: the build is failing because of duplicated lines, but in fact, they are not duplicated, but pointing to different Markdown files, which SonarQube seems to skip. 