### PR TITLE
SD-1560 Reduce AWS Lambda deployment size with 62%

### DIFF
--- a/lambda/pom.xml
+++ b/lambda/pom.xml
@@ -56,6 +56,33 @@
 				<configuration>
 					<createDependencyReducedPom>false</createDependencyReducedPom>
 					<finalName>conformance-lambda</finalName>
+					<minimizeJar>true</minimizeJar>
+					<filters>
+						<filter>
+							<artifact>*:*</artifact>
+							<excludes>
+								<exclude>META-INF/*.SF</exclude>
+								<exclude>META-INF/*.DSA</exclude>
+								<exclude>META-INF/*.RSA</exclude>
+							</excludes>
+						</filter>
+						<!-- Keep all classes from these artifacts. Otherwise, minimizeJar removes them. -->
+						<filter>
+							<artifact>joda-time:joda-time</artifact>
+							<includes>
+								<include>**</include>
+							</includes>
+						</filter>
+						<filter>
+							<artifact>commons-logging:commons-logging</artifact>
+							<includes>
+								<include>**</include>
+							</includes>
+						</filter>
+					</filters>
+					<transformers>
+						<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+					</transformers>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
FYI: 
- Jar file goes from 31MB to 22MB. 
- Tested it in AWS deployment (using CDK) and fixed some errors in few trails, hence the added inclusion filters in the `pom.xml`.