### PR TITLE
SD-2053 Revert update timeout change in ConformanceApplicationTest class

### DIFF
--- a/spring-boot/src/test/java/org/dcsa/conformance/springboot/ConformanceApplicationTest.java
+++ b/spring-boot/src/test/java/org/dcsa/conformance/springboot/ConformanceApplicationTest.java
@@ -74,7 +74,7 @@ class ConformanceApplicationTest {
     String previousStatus = "";
     String startStatus = restTemplate.getForObject("http://localhost:" + port + getAppURL(sandboxId, "status"), String.class);
     do {
-      Thread.sleep(250L);
+      Thread.sleep(500L);
       status = restTemplate.getForObject("http://localhost:" + port + getAppURL(sandboxId, "status"), String.class);
       if (status.equals(previousStatus)) { // Detection of a stuck scenario, prevent waiting forever. Note: turn off while debugging!
         log.error("Status did not change: {}. Originally started at: {}", status, startStatus);


### PR DESCRIPTION
* Sometimes, in a GitHub Actions build run, 500ms sleep is needed for any progress is measured