### PR TITLE
SD-160 JIT 2.0: Update schema to latest

### DIFF
--- a/jit/src/main/resources/standards/jit/schemas/JIT_v2.0.0.yaml
+++ b/jit/src/main/resources/standards/jit/schemas/JIT_v2.0.0.yaml
@@ -90,8 +90,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/portCallIDPathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/Sending-Party'
-        - $ref: '#/components/parameters/Receiving-Party'
+        - $ref: '#/components/parameters/Request-Sending-Party'
+        - $ref: '#/components/parameters/Request-Receiving-Party'
       tags:
         - Port Call Service - Service Consumer
       operationId: put-port-call
@@ -158,12 +158,20 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
         '400':
           description: |
             In case creating a new **Port Call** fails schema validation, a `400` (Bad Request) is returned.
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -195,6 +203,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -225,6 +237,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -255,6 +271,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -288,8 +308,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/portCallIDPathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/Sending-Party'
-        - $ref: '#/components/parameters/Receiving-Party'
+        - $ref: '#/components/parameters/Request-Sending-Party'
+        - $ref: '#/components/parameters/Request-Receiving-Party'
       tags:
         - Port Call Service - Service Consumer
       operationId: omit-port-call
@@ -339,12 +359,20 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
         '400':
           description: |
             In case omitting a **Port Call** fails schema validation, a `400` (Bad Request) is returned.
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -376,6 +404,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -406,6 +438,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -436,6 +472,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -476,8 +516,8 @@ paths:
         - $ref: '#/components/parameters/MMSINumberQueryParam'
 
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/Sending-Party'
-        - $ref: '#/components/parameters/Receiving-Party'
+        - $ref: '#/components/parameters/Request-Sending-Party'
+        - $ref: '#/components/parameters/Request-Receiving-Party'
       tags:
         - Port Call Service
       operationId: get-port-call
@@ -507,6 +547,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -598,6 +642,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -628,6 +676,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -661,8 +713,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/terminalCallIDPathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/Sending-Party'
-        - $ref: '#/components/parameters/Receiving-Party'
+        - $ref: '#/components/parameters/Request-Sending-Party'
+        - $ref: '#/components/parameters/Request-Receiving-Party'
       tags:
         - Port Call Service - Service Consumer
       operationId: put-terminal-call
@@ -731,12 +783,20 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
         '400':
           description: |
             In case creating a new **Terminal Call** fails schema validation, or the provided `portCallID` in the payload cannot be found, a `400` (Bad Request) is returned.
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -787,6 +847,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -817,6 +881,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -847,6 +915,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -880,8 +952,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/terminalCallIDPathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/Sending-Party'
-        - $ref: '#/components/parameters/Receiving-Party'
+        - $ref: '#/components/parameters/Request-Sending-Party'
+        - $ref: '#/components/parameters/Request-Receiving-Party'
       tags:
         - Port Call Service - Service Consumer
       operationId: omit-terminal-call
@@ -930,12 +1002,20 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
         '400':
           description: |
             In case omitting a **Terminal Call** does not schema validate, a `400` (Bad Request) is returned.
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -967,6 +1047,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -997,6 +1081,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1027,6 +1115,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1071,8 +1163,8 @@ paths:
         - $ref: '#/components/parameters/universalExportVoyageReferenceQueryParam'
 
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/Sending-Party'
-        - $ref: '#/components/parameters/Receiving-Party'
+        - $ref: '#/components/parameters/Request-Sending-Party'
+        - $ref: '#/components/parameters/Request-Receiving-Party'
       tags:
         - Port Call Service
       operationId: get-terminal-call
@@ -1114,6 +1206,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1158,6 +1254,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1188,6 +1288,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1221,8 +1325,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/portCallServiceIDPathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/Sending-Party'
-        - $ref: '#/components/parameters/Receiving-Party'
+        - $ref: '#/components/parameters/Request-Sending-Party'
+        - $ref: '#/components/parameters/Request-Receiving-Party'
       tags:
         - Port Call Service - Service Consumer
       operationId: put-port-call-service
@@ -1253,12 +1357,20 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
         '400':
           description: |
             In case creating a new **Port Call Service** fails schema validation, or the referenced `terminalCallID` in the payload does not exist, a `400` (Bad Request) is returned.
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1309,6 +1421,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1339,6 +1455,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1369,6 +1489,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1402,8 +1526,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/portCallServiceIDPathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/Sending-Party'
-        - $ref: '#/components/parameters/Receiving-Party'
+        - $ref: '#/components/parameters/Request-Sending-Party'
+        - $ref: '#/components/parameters/Request-Receiving-Party'
       tags:
         - Port Call Service - Service Consumer
       operationId: cancel-port-call-service
@@ -1433,12 +1557,20 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
         '400':
           description: |
             In case cancelling a **Port Call Service** fails schema validation, a `400` (Bad Request) is returned.
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1470,6 +1602,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1500,6 +1636,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1529,6 +1669,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1566,8 +1710,8 @@ paths:
         - $ref: '#/components/parameters/portCallServiceTypeQueryParam'
 
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/Sending-Party'
-        - $ref: '#/components/parameters/Receiving-Party'
+        - $ref: '#/components/parameters/Request-Sending-Party'
+        - $ref: '#/components/parameters/Request-Receiving-Party'
       tags:
         - Port Call Service
       operationId: get-port-call-services
@@ -1600,6 +1744,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1664,6 +1812,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1693,6 +1845,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1726,8 +1882,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/timestampIDPathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/Sending-Party'
-        - $ref: '#/components/parameters/Receiving-Party'
+        - $ref: '#/components/parameters/Request-Sending-Party'
+        - $ref: '#/components/parameters/Request-Receiving-Party'
       tags:
         - Port Call Service
       operationId: put-timestamp
@@ -1761,12 +1917,20 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
         '400':
           description: |
             In case creating a new **Timestamp** fails schema validation, or the referenced `portCallServiceID` in the payload does not exist, a `400` (Bad Request) is returned.
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1817,6 +1981,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1847,6 +2015,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1877,6 +2049,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1913,8 +2089,8 @@ paths:
         - $ref: '#/components/parameters/classifierCodeQueryParam'
 
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/Sending-Party'
-        - $ref: '#/components/parameters/Receiving-Party'
+        - $ref: '#/components/parameters/Request-Sending-Party'
+        - $ref: '#/components/parameters/Request-Receiving-Party'
       tags:
         - Port Call Service
       operationId: get-timestamp
@@ -1947,6 +2123,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -1982,6 +2162,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -2012,6 +2196,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -2045,8 +2233,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/portCallServiceIDPathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/Sending-Party'
-        - $ref: '#/components/parameters/Receiving-Party'
+        - $ref: '#/components/parameters/Request-Sending-Party'
+        - $ref: '#/components/parameters/Request-Receiving-Party'
       tags:
         - Port Call Service - Service Consumer
       operationId: put-vessel-status
@@ -2075,12 +2263,20 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
         '400':
           description: |
             In case updating a **Vessel Status** fails schema validation, a `400` (Bad Request) is returned.
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -2112,6 +2308,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -2142,6 +2342,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -2172,6 +2376,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -2202,6 +2410,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -2235,8 +2447,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/portCallServiceIDRequiredQueryParam'
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/Sending-Party'
-        - $ref: '#/components/parameters/Receiving-Party'
+        - $ref: '#/components/parameters/Request-Sending-Party'
+        - $ref: '#/components/parameters/Request-Receiving-Party'
       tags:
         - Port Call Service
       operationId: get-vessel-status
@@ -2264,6 +2476,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -2309,6 +2525,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -2339,6 +2559,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -2372,8 +2596,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/portCallServiceIDPathParam'
         - $ref: '#/components/parameters/Api-Version-Major'
-        - $ref: '#/components/parameters/Sending-Party'
-        - $ref: '#/components/parameters/Receiving-Party'
+        - $ref: '#/components/parameters/Request-Sending-Party'
+        - $ref: '#/components/parameters/Request-Receiving-Party'
       tags:
         - Port Call Service - Service Provider
       operationId: decline-port-call-service
@@ -2404,12 +2628,20 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
         '400':
           description: |
             In case declining a **Port Call Service** fails schema validation, a `400` (Bad Request) is returned.
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -2441,6 +2673,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -2471,6 +2707,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -2500,6 +2740,10 @@ paths:
           headers:
             API-Version:
               $ref: '#/components/headers/API-Version'
+            Response-Sending-Party:
+              $ref: '#/components/headers/Response-Sending-Party'
+            Response-Receiving-Party:
+              $ref: '#/components/headers/Response-Receiving-Party'
           content:
             application/json:
               schema:
@@ -2537,6 +2781,22 @@ components:
       description: |
         SemVer used to indicate the version of the contract (API version) returned.
       required: true
+    Response-Sending-Party:
+      required: false
+      schema:
+        type: string
+        maxLength: 4096
+        example: 'Terminal-456'
+      description: |
+        When communicating through an optional system that acts as an application level JIT communication proxy, forwarding API calls between JIT **Service Providers** and JIT **Service Consumers**, the API server sets this response header to identify itself to the JIT proxy and to the API client as the original sending party of the API response. The value of this response header must be the same as the value of the request header `Request-Receiving-Party`. The assignment of party identifiers by the JIT proxy and the distribution of identifiers to the parties connecting through the JIT proxy are out of scope.
+    Response-Receiving-Party:
+      required: false
+      schema:
+        type: string
+        maxLength: 4096
+        example: 'Carrier-123'
+      description: |
+        When communicating through an optional system that acts as an application level JIT communication proxy, forwarding API calls between JIT **Service Providers** and JIT **Service Consumers**, the API server sets this response header to identify to the JIT proxy the target receiving party of the API response. The value of this response header must be the same as the value of the request header `Request-Sending-Party`. The assignment of party identifiers by the JIT proxy and the distribution of identifiers to the parties connecting through the JIT proxy are out of scope.
   parameters:
     Api-Version-Major:
       in: header
@@ -2547,26 +2807,26 @@ components:
         example: '2'
       description: |
         An API-Version header **MAY** be added to the request (optional); if added it **MUST** only contain **MAJOR** version. API-Version header **MUST** be aligned with the URI version.
-    Sending-Party:
+    Request-Sending-Party:
       in: header
-      name: Sending-Party
+      name: Request-Sending-Party
       required: false
       schema:
         type: string
         maxLength: 4096
-        example: 'Sender-7101ad01-d608-483c-b746-e060ba335d51'
+        example: 'Carrier-123'
       description: |
-        In case the request is being sent **on behalf of** another party - it is possible to add the identifier of the party `Sending` the message here. This header can be used when relaying messages.
-    Receiving-Party:
+         When communicating through an optional system that acts as an application level JIT communication proxy, forwarding API calls between JIT **Service Providers** and JIT **Service Consumers**, the API client sets this request header to identify itself to the JIT proxy and to the API server as the original sending party of the API request. The assignment of party identifiers by the JIT proxy and the distribution of identifiers to the parties connecting through the JIT proxy are out of scope.
+    Request-Receiving-Party:
       in: header
-      name: Receiving-Party
+      name: Request-Receiving-Party
       required: false
       schema:
         type: string
         maxLength: 4096
-        example: 'Request-Receiver-fff76466-070b-463e-8dc2-efc55f108e74'
+        example: 'Terminal-456'
       description: |
-        In case the request needs to be received **on behalf of** another party - it is possible to add the identifier of the party `Receiving` the message here. This header can be used when relaying messages.
+        When communicating through an optional system that acts as an application level JIT communication proxy, forwarding API calls between JIT **Service Providers** and JIT **Service Consumers**, the API client sets this request header to identify to the JIT proxy the target receiving party of the API request. The assignment of party identifiers by the JIT proxy and the distribution of identifiers to the parties connecting through the JIT proxy are out of scope.
     ##############
     # Query params
     ##############


### PR DESCRIPTION
### **User description**
Just to update to the latest JIT 2.0 schema from OpenAPI


___

### **PR Type**
Enhancement


___

### **Description**
- Updated API schema to align with JIT 2.0 standards.

- Replaced `Sending-Party` and `Receiving-Party` headers with `Request-Sending-Party` and `Request-Receiving-Party`.

- Added new response headers `Response-Sending-Party` and `Response-Receiving-Party`.

- Enhanced documentation for new headers to clarify their roles in JIT communication.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JIT_v2.0.0.yaml</strong><dd><code>Updated schema with new headers and documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jit/src/main/resources/standards/jit/schemas/JIT_v2.0.0.yaml

<li>Replaced <code>Sending-Party</code> and <code>Receiving-Party</code> headers with <br><code>Request-Sending-Party</code> and <code>Request-Receiving-Party</code>.<br> <li> Added <code>Response-Sending-Party</code> and <code>Response-Receiving-Party</code> headers to <br>responses.<br> <li> Updated descriptions for new headers to clarify their roles in JIT <br>communication.<br> <li> Enhanced API documentation to align with JIT 2.0 standards.


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/295/files#diff-365dfb828910524d1f77f96e7f2340c287fc7378ee176af09dc38228a6f8e63e">+296/-36</a></td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>