### PR TITLE
SD-2120 Supplied scenario parameters must match the expected ones

### DIFF
--- a/adoption/src/main/java/org/dcsa/conformance/standards/adoption/action/SupplyScenarioParametersAction.java
+++ b/adoption/src/main/java/org/dcsa/conformance/standards/adoption/action/SupplyScenarioParametersAction.java
@@ -95,8 +95,7 @@ public class SupplyScenarioParametersAction extends ConformanceAction {
   }
 
   @Override
-  public void handlePartyInput(JsonNode partyInput) {
-    super.handlePartyInput(partyInput);
+  protected void doHandlePartyInput(JsonNode partyInput) {
     try {
       JsonNode input = partyInput.get("input");
 

--- a/adoption/src/test/java/org/dcsa/conformance/standards/adoption/action/SupplyScenarioParametersActionTest.java
+++ b/adoption/src/test/java/org/dcsa/conformance/standards/adoption/action/SupplyScenarioParametersActionTest.java
@@ -21,7 +21,7 @@ class SupplyScenarioParametersActionTest {
   })
   void testHandlePartyInput(String date, String interval) {
     JsonNode inputNode = OBJECT_MAPPER.createObjectNode().set("input", OBJECT_MAPPER.createObjectNode().put("date", date).put("interval", interval));
-    action.handlePartyInput(inputNode);
+    action.doHandlePartyInput(inputNode);
     String output = action.getSuppliedScenarioParameters().toJson().toString();
     assertTrue(output.contains("\"interval\":\"%s\"".formatted(interval)));
     assertTrue(output.contains("\"date\":\"%s\"".formatted(date)));
@@ -38,6 +38,6 @@ class SupplyScenarioParametersActionTest {
   })
   void testHandlePartyInputWrongDataShouldThrowException(String date, String interval) {
     JsonNode inputNode = OBJECT_MAPPER.createObjectNode().set("input", OBJECT_MAPPER.createObjectNode().put("date", date).put("interval", interval));
-    assertThrows(UserFacingException.class, () -> action.handlePartyInput(inputNode));
+    assertThrows(UserFacingException.class, () -> action.doHandlePartyInput(inputNode));
   }
 }

--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/action/Carrier_SupplyScenarioParametersAction.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/action/Carrier_SupplyScenarioParametersAction.java
@@ -68,8 +68,7 @@ public class Carrier_SupplyScenarioParametersAction extends BookingAction {
   }
 
   @Override
-  public void handlePartyInput(JsonNode partyInput) {
-    super.handlePartyInput(partyInput);
+  protected void doHandlePartyInput(JsonNode partyInput) {
     getCspConsumer().accept(CarrierScenarioParameters.fromJson(partyInput.get("input")));
   }
 

--- a/commercial-schedules/src/main/java/org/dcsa/conformance/standards/cs/action/SupplyScenarioParametersAction.java
+++ b/commercial-schedules/src/main/java/org/dcsa/conformance/standards/cs/action/SupplyScenarioParametersAction.java
@@ -85,8 +85,7 @@ public class SupplyScenarioParametersAction extends CsAction {
   }
 
   @Override
-  public void handlePartyInput(JsonNode partyInput) {
-    super.handlePartyInput(partyInput);
+  protected void doHandlePartyInput(JsonNode partyInput) {
     suppliedScenarioParameters = SuppliedScenarioParameters.fromJson(partyInput.get("input"));
   }
 

--- a/core/src/main/java/org/dcsa/conformance/core/scenario/ConformanceAction.java
+++ b/core/src/main/java/org/dcsa/conformance/core/scenario/ConformanceAction.java
@@ -4,11 +4,18 @@ import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.dcsa.conformance.core.UserFacingException;
@@ -226,7 +233,40 @@ public abstract class ConformanceAction implements StatefulEntity {
     return null;
   }
 
-  public void handlePartyInput(JsonNode partyInput) throws UserFacingException {}
+  public void handlePartyInput(JsonNode partyInput) throws UserFacingException {
+    JsonNode jsonForHumanReadablePrompt = getJsonForHumanReadablePrompt();
+    if (jsonForHumanReadablePrompt != null) {
+      Set<String> expectedAttributes =
+          StreamSupport.stream(
+                  Spliterators.spliteratorUnknownSize(
+                      jsonForHumanReadablePrompt.fieldNames(), Spliterator.ORDERED),
+                  false)
+              .collect(Collectors.toSet());
+      if (!expectedAttributes.isEmpty()) { // because "empty" means "any input is allowed"
+        Set<String> providedAttributes =
+            StreamSupport.stream(
+                    Spliterators.spliteratorUnknownSize(
+                        partyInput.get("input").fieldNames(), Spliterator.ORDERED),
+                    false)
+                .collect(Collectors.toSet());
+        Set<String> missingAttributes = new HashSet<>(expectedAttributes);
+        missingAttributes.removeAll(providedAttributes);
+        if (!missingAttributes.isEmpty()) {
+          throw new UserFacingException(
+            "The input must contain: %s".formatted(String.join(", ", missingAttributes)));
+        }
+        Set<String> unexpectedAttributes = new HashSet<>(providedAttributes);
+        unexpectedAttributes.removeAll(expectedAttributes);
+        if (!unexpectedAttributes.isEmpty()) {
+          throw new UserFacingException(
+            "The input may not contain: %s".formatted(String.join(", ", unexpectedAttributes)));
+        }
+      }
+    }
+    doHandlePartyInput(partyInput);
+  }
+
+  protected void doHandlePartyInput(JsonNode partyInput) throws UserFacingException {}
 
   public ObjectNode asJsonNode() {
     return OBJECT_MAPPER

--- a/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/action/CarrierScenarioParametersAction.java
+++ b/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/action/CarrierScenarioParametersAction.java
@@ -59,7 +59,7 @@ public class CarrierScenarioParametersAction extends IssuanceAction {
   }
 
   @Override
-  public void handlePartyInput(JsonNode partyInput) {
+  protected void doHandlePartyInput(JsonNode partyInput) {
     CarrierScenarioParameters carrierScenarioParameters = CarrierScenarioParameters.fromJson(partyInput.get("input"));
     // validate the carrier signing key
     PayloadSignerFactory.verifierFromPemEncodedCertificate(

--- a/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/action/PlatformScenarioParametersAction.java
+++ b/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/action/PlatformScenarioParametersAction.java
@@ -97,8 +97,7 @@ public class PlatformScenarioParametersAction extends IssuanceAction {
   }
 
   @Override
-  public void handlePartyInput(JsonNode partyInput) {
-    super.handlePartyInput(partyInput);
+  protected void doHandlePartyInput(JsonNode partyInput) {
     setDsp(getDsp().withEblType(eblType));
     getSspConsumer().accept(SuppliedScenarioParameters.fromJson(partyInput.get("input")));
   }

--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SupplyScenarioParametersAction.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SupplyScenarioParametersAction.java
@@ -88,8 +88,7 @@ public class SupplyScenarioParametersAction extends ConformanceAction {
   }
 
   @Override
-  public void handlePartyInput(JsonNode partyInput) {
-    super.handlePartyInput(partyInput);
+  protected void doHandlePartyInput(JsonNode partyInput) {
     suppliedScenarioParameters = SuppliedScenarioParameters.fromJson(partyInput.get("input"));
   }
 

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/action/Carrier_SupplyScenarioParametersAction.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/action/Carrier_SupplyScenarioParametersAction.java
@@ -178,8 +178,7 @@ public class Carrier_SupplyScenarioParametersAction extends EblAction {
   }
 
   @Override
-  public void handlePartyInput(JsonNode partyInput) {
-    super.handlePartyInput(partyInput);
+  protected void doHandlePartyInput(JsonNode partyInput) {
     getCspConsumer().accept(CarrierScenarioParameters.fromJson(partyInput.get("input")));
     validateCSR(carrierScenarioParameters, scenarioType);
   }

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/action/UC6_Carrier_PublishDraftTransportDocumentAction.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/action/UC6_Carrier_PublishDraftTransportDocumentAction.java
@@ -65,8 +65,7 @@ public class UC6_Carrier_PublishDraftTransportDocumentAction extends StateChangi
   }
 
   @Override
-  public void handlePartyInput(JsonNode partyInput) throws UserFacingException {
-    super.handlePartyInput(partyInput);
+  protected void doHandlePartyInput(JsonNode partyInput) throws UserFacingException {
     getDspConsumer()
         .accept(
             getDspSupplier()

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitOOBTimestampInputAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/JitOOBTimestampInputAction.java
@@ -51,9 +51,8 @@ public class JitOOBTimestampInputAction extends JitAction {
   }
 
   @Override
-  public void handlePartyInput(JsonNode partyInput) {
+  protected void doHandlePartyInput(JsonNode partyInput) {
     log.info("JitOOBTimestampInputAction.handlePartyInput({})", partyInput.toPrettyString());
-    super.handlePartyInput(partyInput);
     if (dsp == null) dsp = ((JitAction) previousAction).dsp;
 
     // Store supplied timestamp into the DSP

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/action/SupplyScenarioParametersAction.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/action/SupplyScenarioParametersAction.java
@@ -63,9 +63,8 @@ public class SupplyScenarioParametersAction extends JitAction {
   }
 
   @Override
-  public void handlePartyInput(JsonNode partyInput) {
+  protected void doHandlePartyInput(JsonNode partyInput) {
     log.info("SupplyScenarioParametersAction.handlePartyInput({})", partyInput.toPrettyString());
-    super.handlePartyInput(partyInput);
     suppliedScenarioParameters = SuppliedScenarioParameters.fromJson(partyInput.get("input"));
 
     dsp =

--- a/ovs/src/main/java/org/dcsa/conformance/standards/ovs/action/SupplyScenarioParametersAction.java
+++ b/ovs/src/main/java/org/dcsa/conformance/standards/ovs/action/SupplyScenarioParametersAction.java
@@ -3,16 +3,12 @@ package org.dcsa.conformance.standards.ovs.action;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
 import lombok.Getter;
 import org.dcsa.conformance.core.UserFacingException;
 import org.dcsa.conformance.standards.ovs.party.OvsFilterParameter;
@@ -95,28 +91,8 @@ public class SupplyScenarioParametersAction extends OvsAction {
   }
 
   @Override
-  public void handlePartyInput(JsonNode partyInput) {
-    super.handlePartyInput(partyInput);
+  protected void doHandlePartyInput(JsonNode partyInput) {
     JsonNode inputNode = partyInput.get("input");
-    Set<String> inputKeys =
-      StreamSupport.stream(
-          ((Iterable<String>) inputNode::fieldNames)
-            .spliterator(),
-          false)
-        .collect(Collectors.toSet());
-
-    Set<String> missingKeys =
-      StreamSupport.stream(
-          ((Iterable<String>) () -> getJsonForHumanReadablePrompt().fieldNames())
-            .spliterator(),
-          false)
-        .collect(Collectors.toSet());
-    missingKeys.removeAll(inputKeys);
-    if (!missingKeys.isEmpty()) {
-      throw new UserFacingException(
-        "The input must contain: %s".formatted(String.join(", ", missingKeys)));
-    }
-
     Arrays.stream(OvsFilterParameter.values())
         .map(OvsFilterParameter::getQueryParamName)
         .filter(

--- a/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/action/ReceiverSupplyScenarioParametersAndStateSetupAction.java
+++ b/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/action/ReceiverSupplyScenarioParametersAndStateSetupAction.java
@@ -42,8 +42,7 @@ public class ReceiverSupplyScenarioParametersAndStateSetupAction extends PintAct
   }
 
   @Override
-  public void handlePartyInput(JsonNode partyInput) {
-    super.handlePartyInput(partyInput);
+  protected void doHandlePartyInput(JsonNode partyInput) {
     var rsp = ReceiverScenarioParameters.fromJson(partyInput.path("input"));
     rsp.validate();
     this.setRsp(rsp);

--- a/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/action/SenderSupplyScenarioParametersAction.java
+++ b/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/action/SenderSupplyScenarioParametersAction.java
@@ -32,8 +32,7 @@ public class SenderSupplyScenarioParametersAction extends PintAction {
   }
 
   @Override
-  public void handlePartyInput(JsonNode partyInput) {
-    super.handlePartyInput(partyInput);
+  protected void doHandlePartyInput(JsonNode partyInput) {
     var ssp = SenderScenarioParameters.fromJson(partyInput.path("input"));
     ssp.validate();
     this.setSsp(ssp);

--- a/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/action/SupplyValidationEndpointScenarioParametersAction.java
+++ b/pint/src/main/java/org/dcsa/conformance/standards/eblinterop/action/SupplyValidationEndpointScenarioParametersAction.java
@@ -29,8 +29,7 @@ public class SupplyValidationEndpointScenarioParametersAction extends PintAction
   }
 
   @Override
-  public void handlePartyInput(JsonNode partyInput) {
-    super.handlePartyInput(partyInput);
+  protected void doHandlePartyInput(JsonNode partyInput) {
     setDsp(getDsp().withReceiverValidation(partyInput.path("input")));
   }
 

--- a/tnt/src/main/java/org/dcsa/conformance/standards/tnt/action/SupplyScenarioParametersAction.java
+++ b/tnt/src/main/java/org/dcsa/conformance/standards/tnt/action/SupplyScenarioParametersAction.java
@@ -8,9 +8,7 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import lombok.Getter;
 import org.dcsa.conformance.core.UserFacingException;
@@ -98,29 +96,8 @@ public class SupplyScenarioParametersAction extends TntAction {
   }
 
   @Override
-  public void handlePartyInput(JsonNode partyInput) {
-    super.handlePartyInput(partyInput);
-
+  protected void doHandlePartyInput(JsonNode partyInput) {
     JsonNode inputNode = partyInput.get("input");
-    Set<String> inputKeys =
-      StreamSupport.stream(
-          ((Iterable<String>) inputNode::fieldNames)
-            .spliterator(),
-          false)
-        .collect(Collectors.toSet());
-
-    Set<String> missingKeys =
-      StreamSupport.stream(
-          ((Iterable<String>) () -> getJsonForHumanReadablePrompt().fieldNames())
-            .spliterator(),
-          false)
-        .collect(Collectors.toSet());
-    missingKeys.removeAll(inputKeys);
-    if (!missingKeys.isEmpty()) {
-      throw new UserFacingException(
-          "The input must contain: %s".formatted(String.join(", ", missingKeys)));
-    }
-
     Arrays.stream(TntFilterParameter.values())
         .map(TntFilterParameter::getQueryParamName)
         .filter(


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored `handlePartyInput` method to enforce stricter parameter validation.
  - Introduced `doHandlePartyInput` as a protected method for specific implementations.
  - Added validation for expected and unexpected attributes in `ConformanceAction`.

- Updated test cases to align with the new `doHandlePartyInput` method.

- Removed redundant validation logic from individual `handlePartyInput` implementations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td><strong>SupplyScenarioParametersAction.java</strong><dd><code>Refactored `handlePartyInput` to `doHandlePartyInput`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/300/files#diff-887c9f1c5bce8e8030fcf541ef289b30df64f2d87af95e11d037db663aa551e2">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Carrier_SupplyScenarioParametersAction.java</strong><dd><code>Refactored `handlePartyInput` to `doHandlePartyInput`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/300/files#diff-723a0756957dcaf64bfca1c36949f4d9517344a4966971d39834c12f21010c27">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SupplyScenarioParametersAction.java</strong><dd><code>Refactored `handlePartyInput` to `doHandlePartyInput`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/300/files#diff-aa694811829f66dc526b544b683a0af5bd8ed11227901eed9e3509d152eac67d">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CarrierScenarioParametersAction.java</strong><dd><code>Refactored `handlePartyInput` to `doHandlePartyInput`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/300/files#diff-c97b74fcbd65b003adb85af0ede2b5a0a46eea2890b85351367478a39aceae8f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PlatformScenarioParametersAction.java</strong><dd><code>Refactored `handlePartyInput` to `doHandlePartyInput`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/300/files#diff-4368b594e35e23ae7b2fb5d2adb3b0826198d2d89c975ff4019709dd0abf0bcc">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SupplyScenarioParametersAction.java</strong><dd><code>Refactored `handlePartyInput` to `doHandlePartyInput`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/300/files#diff-a7c7500036609581821fd765e7bbcd5dc341370b2c5ffcf63c500ed42d537755">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Carrier_SupplyScenarioParametersAction.java</strong><dd><code>Refactored `handlePartyInput` to `doHandlePartyInput`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/300/files#diff-dcc07889900255f6abd28e1cea002a4f79a9202874b5cb5067e7f30bf66c7b6b">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>UC6_Carrier_PublishDraftTransportDocumentAction.java</strong><dd><code>Refactored `handlePartyInput` to `doHandlePartyInput`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/300/files#diff-b7c8c5107852bee7eb4edcef25368db0520555931ed92761f0fd3aa0775feeaa">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>JitOOBTimestampInputAction.java</strong><dd><code>Refactored `handlePartyInput` to `doHandlePartyInput`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/300/files#diff-2f6ba93f4241f54701a5bcd6e459be919ac5c052bf9a3908df278c6cc629087b">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SupplyScenarioParametersAction.java</strong><dd><code>Refactored `handlePartyInput` to `doHandlePartyInput`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/300/files#diff-95604c762f27e321abf550d92fc17182ef399261a5ac011212869aa697518e41">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SupplyScenarioParametersAction.java</strong><dd><code>Refactored <code>handlePartyInput</code> to <code>doHandlePartyInput</code> and removed <br>redundant validation</code></dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/300/files#diff-52a13ac208a6dc9eaf8abb7c9d86acc00c0d65b2dc9a397ac0594f04a0cd3f65">+1/-25</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ReceiverSupplyScenarioParametersAndStateSetupAction.java</strong><dd><code>Refactored `handlePartyInput` to `doHandlePartyInput`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/300/files#diff-7892bdbeaa6b77cac8faf745b0bb13b19a7f69e2d0470c616f98026e658b9dca">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SenderSupplyScenarioParametersAction.java</strong><dd><code>Refactored `handlePartyInput` to `doHandlePartyInput`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/300/files#diff-9bd76e060d95807a6a9449a73fe74845950e923d3e6df8f63eb5f3bf4470f23b">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SupplyValidationEndpointScenarioParametersAction.java</strong><dd><code>Refactored `handlePartyInput` to `doHandlePartyInput`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/300/files#diff-5b5f5820afb9a26cbff7b64b35e4c9ca9bd93df6a6919adcbbadaab7ce2490a5">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SupplyScenarioParametersAction.java</strong><dd><code>Refactored <code>handlePartyInput</code> to <code>doHandlePartyInput</code> and removed <br>redundant validation</code></dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/300/files#diff-720ab363c7549bf882f27c9fa2f897c0c10e7d5355b4d19bf15a4cd84339b050">+1/-24</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>SupplyScenarioParametersActionTest.java</strong><dd><code>Updated tests to use `doHandlePartyInput`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/300/files#diff-1d3aa8a47799ececafb7ab205c5af9fc977a82afc4a39ad1e9ae0c5c398acfed">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ConformanceAction.java</strong><dd><code>Added validation for expected and unexpected attributes</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/300/files#diff-05278dffb376653b12914181aa5aad18abdf5b2b1b8e8178d4dd623f13e3d333">+41/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>