### PR TITLE
Sd 2024 remove bkg dangerous goods validations

### DIFF
--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/action/Carrier_SupplyScenarioParametersAction.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/action/Carrier_SupplyScenarioParametersAction.java
@@ -7,6 +7,7 @@ import java.util.function.Supplier;
 import lombok.NonNull;
 import org.dcsa.conformance.standards.booking.checks.ScenarioType;
 import org.dcsa.conformance.standards.booking.party.BookingCarrier;
+import org.dcsa.conformance.standards.booking.party.CarrierScenarioJsonAdapter;
 import org.dcsa.conformance.standards.booking.party.CarrierScenarioParameters;
 
 public class Carrier_SupplyScenarioParametersAction extends BookingAction {
@@ -59,7 +60,8 @@ public class Carrier_SupplyScenarioParametersAction extends BookingAction {
 
   @Override
   public JsonNode getJsonForHumanReadablePrompt() {
-    return BookingCarrier.getCarrierScenarioParameters(scenarioType).toJson();
+    carrierScenarioParameters = BookingCarrier.getCarrierScenarioParameters(scenarioType);
+    return CarrierScenarioJsonAdapter.toJson(carrierScenarioParameters, scenarioType);
   }
 
   @Override

--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/party/BookingCarrier.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/party/BookingCarrier.java
@@ -118,7 +118,8 @@ public class BookingCarrier extends ConformanceParty {
     var scenarioType = ScenarioType.valueOf(actionPrompt.required("scenarioType").asText());
     CarrierScenarioParameters carrierScenarioParameters = getCarrierScenarioParameters(scenarioType);
     asyncOrchestratorPostPartyInput(
-        actionPrompt.get("actionId").asText(), carrierScenarioParameters.toJson());
+        actionPrompt.get("actionId").asText(),
+        CarrierScenarioJsonAdapter.toJson(carrierScenarioParameters, scenarioType));
     addOperatorLogEntry(
         "Provided CarrierScenarioParameters: %s".formatted(carrierScenarioParameters));
   }
@@ -203,8 +204,8 @@ public class BookingCarrier extends ConformanceParty {
               EXAMPLE_CARRIER_SERVICE,
               "403W",
               "TA1",
-              "293499",
-              "Environmentally hazardous substance, liquid, N.O.S (Propiconazole)",
+              "293498",
+              null,
               null,
               null,
               DKAAR,

--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/party/CarrierScenarioJsonAdapter.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/party/CarrierScenarioJsonAdapter.java
@@ -1,4 +1,23 @@
 package org.dcsa.conformance.standards.booking.party;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.dcsa.conformance.standards.booking.checks.ScenarioType;
+
 public class CarrierScenarioJsonAdapter {
+
+  public static final String COMMODITY_TYPE_1 = "commodityType1";
+  public static final String COMMODITY_TYPE_2 = "commodityType2";
+
+  private CarrierScenarioJsonAdapter() {}
+
+  public static ObjectNode toJson(CarrierScenarioParameters params, ScenarioType scenarioType) {
+    ObjectNode json = params.toJson();
+
+    if (ScenarioType.DG.equals(scenarioType)) {
+      json.remove(COMMODITY_TYPE_1);
+      json.remove(COMMODITY_TYPE_2);
+    }
+
+    return json;
+  }
 }

--- a/booking/src/main/resources/standards/booking/messages/booking-api-2.0.0-dg.json
+++ b/booking/src/main/resources/standards/booking/messages/booking-api-2.0.0-dg.json
@@ -19,7 +19,7 @@
       "commodities": [
         {
           "HSCodes": ["COMMODITY_HS_CODE_1"],
-          "commodityType": "COMMODITY_TYPE_1_PLACEHOLDER",
+          "commodityType": "Environmentally hazardous substance, liquid, N.O.S (Propiconazole)",
           "cargoGrossWeight": {
             "value": 12000,
             "unit": "KGM"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed unnecessary `commodityType` fields for DG booking scenarios

- Introduced `CarrierScenarioJsonAdapter` to handle scenario-specific JSON serialization

- Updated DG scenario parameters and example message accordingly


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Carrier_SupplyScenarioParametersAction.java</strong><dd><code>Use adapter to serialize scenario parameters for prompts</code>&nbsp; </dd></summary>
<hr>

booking/src/main/java/org/dcsa/conformance/standards/booking/action/Carrier_SupplyScenarioParametersAction.java

<li>Replaced direct JSON serialization with new adapter for scenario <br>parameters<br> <li> Ensures DG scenario omits unnecessary commodityType fields


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/321/files#diff-723a0756957dcaf64bfca1c36949f4d9517344a4966971d39834c12f21010c27">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BookingCarrier.java</strong><dd><code>Refactor to use scenario-aware JSON serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

booking/src/main/java/org/dcsa/conformance/standards/booking/party/BookingCarrier.java

<li>Updated to use new JSON adapter for scenario parameters<br> <li> DG scenario parameters now omit redundant commodityType fields


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/321/files#diff-5bece6bea55d218c30f49438173d4ef8b23d8c68aa3cba3318f53770134ccbb1">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CarrierScenarioJsonAdapter.java</strong><dd><code>Add adapter to customize scenario parameter JSON output</code>&nbsp; &nbsp; </dd></summary>
<hr>

booking/src/main/java/org/dcsa/conformance/standards/booking/party/CarrierScenarioJsonAdapter.java

<li>Added new adapter class for scenario parameter JSON serialization<br> <li> Removes commodityType fields for DG scenarios


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/321/files#diff-33e923eca6af78c467d32da4bc45bfcbfc9e9f398d1c4668a2557c95bf828f65">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>booking-api-2.0.0-dg.json</strong><dd><code>Update DG booking example to match new parameter structure</code></dd></summary>
<hr>

booking/src/main/resources/standards/booking/messages/booking-api-2.0.0-dg.json

<li>Updated DG example to use specific commodityType value<br> <li> Removed placeholder for commodityType


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/321/files#diff-45b4c1d768b25b1f3ab79f572e69ce5cf8bf0cfab31ff23a3789d89bbfecb908">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>