### PR TITLE
Sd 1999 fix jit sanbox builder

### DIFF
--- a/core/src/main/java/org/dcsa/conformance/core/AbstractComponentFactory.java
+++ b/core/src/main/java/org/dcsa/conformance/core/AbstractComponentFactory.java
@@ -111,7 +111,7 @@ public abstract class AbstractComponentFactory {
             : "%s-%s-%s"
                 .formatted(
                     autoOrManualInfix,
-                    testedPartyRole.toLowerCase().replaceAll("\\s+", "-"),
+                    getFormattedTestedPartyRole(testedPartyRole),
                     isTestingCounterpartsConfig ? "testing-counterparts" : "tested-party");
 
     ObjectNode sandboxNode = JsonToolkit.OBJECT_MAPPER.createObjectNode();
@@ -170,11 +170,10 @@ public abstract class AbstractComponentFactory {
                                         ? "all-in-one"
                                         : "%s-testing-counterparts"
                                             .formatted(
-                                                (Objects.equals(testedPartyRole, roleOne)
+                                                getFormattedTestedPartyRole(
+                                                    (Objects.equals(testedPartyRole, roleOne)
                                                         ? roleOne
-                                                        : roleTwo)
-                                                    .toLowerCase()
-                                                    .replaceAll("\\s+", "-"))));
+                                                        : roleTwo)))));
                 if (isManual && roleName.equals(testedPartyRole))
                   rolePartyNode.put("inManualMode", true);
                 partiesNode.add(rolePartyNode);
@@ -196,9 +195,7 @@ public abstract class AbstractComponentFactory {
                                         ? "all-in-one"
                                         : "%s-%s"
                                             .formatted(
-                                                testedPartyRole
-                                                    .toLowerCase()
-                                                    .replaceAll("\\s+", "-"),
+                                                getFormattedTestedPartyRole(testedPartyRole),
                                                 roleName.equals(testedPartyRole)
                                                     ? "tested-party"
                                                     : "testing-counterparts"),
@@ -217,6 +214,10 @@ public abstract class AbstractComponentFactory {
               }
             });
     return sandboxNode;
+  }
+
+  private static String getFormattedTestedPartyRole(String testedPartyRole) {
+    return testedPartyRole.toLowerCase().replaceAll("\\s+", "-");
   }
 
   protected static String _findPartyOrCounterpartName(

--- a/core/src/main/java/org/dcsa/conformance/core/AbstractComponentFactory.java
+++ b/core/src/main/java/org/dcsa/conformance/core/AbstractComponentFactory.java
@@ -173,7 +173,8 @@ public abstract class AbstractComponentFactory {
                                                 (Objects.equals(testedPartyRole, roleOne)
                                                         ? roleOne
                                                         : roleTwo)
-                                                    .toLowerCase())));
+                                                    .toLowerCase()
+                                                    .replaceAll("\\s+", "-"))));
                 if (isManual && roleName.equals(testedPartyRole))
                   rolePartyNode.put("inManualMode", true);
                 partiesNode.add(rolePartyNode);
@@ -195,7 +196,9 @@ public abstract class AbstractComponentFactory {
                                         ? "all-in-one"
                                         : "%s-%s"
                                             .formatted(
-                                                testedPartyRole.toLowerCase(),
+                                                testedPartyRole
+                                                    .toLowerCase()
+                                                    .replaceAll("\\s+", "-"),
                                                 roleName.equals(testedPartyRole)
                                                     ? "tested-party"
                                                     : "testing-counterparts"),

--- a/core/src/main/java/org/dcsa/conformance/core/AbstractComponentFactory.java
+++ b/core/src/main/java/org/dcsa/conformance/core/AbstractComponentFactory.java
@@ -111,7 +111,7 @@ public abstract class AbstractComponentFactory {
             : "%s-%s-%s"
                 .formatted(
                     autoOrManualInfix,
-                    testedPartyRole.toLowerCase(),
+                    testedPartyRole.toLowerCase().replaceAll("\\s+", "-"),
                     isTestingCounterpartsConfig ? "testing-counterparts" : "tested-party");
 
     ObjectNode sandboxNode = JsonToolkit.OBJECT_MAPPER.createObjectNode();

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitConsumer.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitConsumer.java
@@ -88,8 +88,6 @@ public class JitConsumer extends ConformanceParty {
 
     addOperatorLogEntry(
         "Submitted SuppliedScenarioParameters: %s".formatted(parameters.toJson().toPrettyString()));
-
-    JitPartyHelper.flushTimestamps(persistentMap); // Prevent timestamps from being reused
   }
 
   public static SuppliedScenarioParameters createSuppliedScenarioParameters(

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitConsumer.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitConsumer.java
@@ -63,7 +63,7 @@ public class JitConsumer extends ConformanceParty {
 
   @Override
   protected void doReset() {
-    // No state to reset.
+    JitPartyHelper.flushTimestamps(persistentMap);
   }
 
   @Override

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitPartyHelper.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitPartyHelper.java
@@ -269,10 +269,6 @@ public class JitPartyHelper {
     return response;
   }
 
-  static void flushTimestamps(JsonNodeMap persistentMap) {
-    persistentMap.save(JitGetType.TIMESTAMPS.name(), OBJECT_MAPPER.createArrayNode());
-  }
-
   // Save the response for generating GET requests. Add it to the list of timestamps.
   static void storeTimestamp(JsonNodeMap persistentMap, JitTimestamp timestamp) {
     ArrayNode timestamps = (ArrayNode) persistentMap.load(JitGetType.TIMESTAMPS.name());

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitPartyHelper.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitPartyHelper.java
@@ -269,6 +269,10 @@ public class JitPartyHelper {
     return response;
   }
 
+  static void flushTimestamps(JsonNodeMap persistentMap) {
+    persistentMap.save(JitGetType.TIMESTAMPS.name(), OBJECT_MAPPER.createArrayNode());
+  }
+
   // Save the response for generating GET requests. Add it to the list of timestamps.
   static void storeTimestamp(JsonNodeMap persistentMap, JitTimestamp timestamp) {
     ArrayNode timestamps = (ArrayNode) persistentMap.load(JitGetType.TIMESTAMPS.name());

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitProvider.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitProvider.java
@@ -101,7 +101,6 @@ public class JitProvider extends ConformanceParty {
 
     persistentMap.save(
         JitGetType.PORT_CALLS.name(), jsonBody); // Save the response for generating GET requests.
-    JitPartyHelper.flushTimestamps(persistentMap); // Prevent timestamps from being reused (if any).
 
     addOperatorLogEntry(
         "Submitted Port Call request for portCallID: %s".formatted(dsp.portCallID()));

--- a/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitProvider.java
+++ b/jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitProvider.java
@@ -71,7 +71,7 @@ public class JitProvider extends ConformanceParty {
 
   @Override
   protected void doReset() {
-    // No state to reset.
+    JitPartyHelper.flushTimestamps(persistentMap);
   }
 
   @Override


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Normalize whitespace in `testedPartyRole` to hyphens for sandbox IDs and URLs.

- Remove obsolete `flushTimestamps` workaround in JIT party classes.

- Refactor related code for improved consistency and clarity.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AbstractComponentFactory.java</strong><dd><code>Normalize whitespace in sandbox ID and URL generation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/src/main/java/org/dcsa/conformance/core/AbstractComponentFactory.java

<li>Replace whitespace with hyphens in <code>testedPartyRole</code> for sandbox IDs and <br>URLs.<br> <li> Ensure consistent ID and URL formatting across sandbox configuration <br>logic.


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/325/files#diff-b7a1af9c2d8b707c215798d9c0a8d5e04ff98ba3ece0556244e95755c1f2f372">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>JitPartyHelper.java</strong><dd><code>Remove unused flushTimestamps method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitPartyHelper.java

- Remove unused `flushTimestamps` method from helper class.


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/325/files#diff-e744f4012f5da1363d773eba37be365d61fd79a03014a57a459c38510cece585">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JitConsumer.java</strong><dd><code>Remove obsolete timestamp flush in scenario parameter submission</code></dd></summary>
<hr>

jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitConsumer.java

<li>Remove call to obsolete <code>flushTimestamps</code> method after scenario <br>parameter submission.


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/325/files#diff-7cc1160ea9fcbbfedf31d78faf30bedf2902e38a7e555d959a2cff3ff0df906f">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>JitProvider.java</strong><dd><code>Remove obsolete timestamp flush in port call request</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jit/src/main/java/org/dcsa/conformance/standards/jit/party/JitProvider.java

<li>Remove call to obsolete <code>flushTimestamps</code> after saving port call <br>response.


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/325/files#diff-f9fc199834fa3bc8639aa2d43eb82e90ec06b1d7ba9bc29dabf7ca7a0dc94fbd">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>