### PR TITLE
Sd 2235 clean booking payload after uc1

### DIFF
--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/action/UC1_Shipper_SubmitBookingRequestAction.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/action/UC1_Shipper_SubmitBookingRequestAction.java
@@ -1,10 +1,13 @@
 package org.dcsa.conformance.standards.booking.action;
 
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.dcsa.conformance.core.check.*;
+import org.dcsa.conformance.core.traffic.ConformanceExchange;
 import org.dcsa.conformance.core.traffic.HttpMessageType;
 import org.dcsa.conformance.standards.booking.checks.BookingChecks;
 import org.dcsa.conformance.standards.booking.party.BookingRole;
@@ -80,5 +83,11 @@ public class UC1_Shipper_SubmitBookingRequestAction extends StateChangingBooking
                     expectedApiVersion, notificationSchemaValidator, BookingState.RECEIVED, null)));
       }
     };
+  }
+
+  @Override
+  protected void doHandleExchange(ConformanceExchange exchange) {
+    super.doHandleExchange(exchange);
+    getBookingPayloadConsumer().accept(OBJECT_MAPPER.createObjectNode());
   }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
• Clear booking payload from CSP after UC1 completion
• Add payload cleanup logic to prevent data persistence


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UC1_Shipper_SubmitBookingRequestAction.java</strong><dd><code>Add booking payload cleanup after exchange</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

booking/src/main/java/org/dcsa/conformance/standards/booking/action/UC1_Shipper_SubmitBookingRequestAction.java

• Added static import for <code>OBJECT_MAPPER</code><br> • Added import for <br><code>ConformanceExchange</code><br> • Implemented <code>doHandleExchange</code> method to clear <br>booking payload<br> • Set booking payload consumer to empty ObjectNode <br>after exchange


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/330/files#diff-91bf1e6ab972a56b3b4b7f8438b257b4ed1a18f3074da916782d9011cdd69cd8">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>