### PR TITLE
SD-2256: Skip validation of notification when booking and amended boo…

### DIFF
--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/checks/CarrierBookingNotificationDataPayloadRequestConformanceCheck.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/checks/CarrierBookingNotificationDataPayloadRequestConformanceCheck.java
@@ -86,9 +86,7 @@ public class CarrierBookingNotificationDataPayloadRequestConformanceCheck
                     "Validate 'data.feedbacks' severity and code are valid",
                     at(DATA_PATH, this::ensureFeedbackSeverityAndCodeCompliance))),
             createFullNotificationChecksAt(BOOKING_PATH, BOOKING_PREFIX),
-            expectedAmendedBookingStatus != null
-                ? createFullNotificationChecksAt(AMENDED_BOOKING_PATH, AMENDED_BOOKING_PREFIX)
-                : Stream.<ConformanceCheck>empty())
+            createFullNotificationChecksAt(AMENDED_BOOKING_PATH, AMENDED_BOOKING_PREFIX))
         .flatMap(Function.identity());
   }
 
@@ -105,6 +103,13 @@ public class CarrierBookingNotificationDataPayloadRequestConformanceCheck
                 createSubCheck(
                     prefix,
                     jsonContentCheck.description(),
-                    at(jsonPath, jsonContentCheck::validate)));
+                    at(
+                        jsonPath,
+                        jsonNode -> {
+                          if (jsonNode.isMissingNode() || jsonNode.isEmpty()) {
+                            return Set.of();
+                          }
+                          return jsonContentCheck.validate(jsonNode);
+                        })));
   }
 }


### PR DESCRIPTION
### **User description**
…king are not present in the payload


___

### **PR Type**
Bug fix


___

### **Description**
- Skip validation when booking/amended booking nodes are missing

- Remove conditional check for amended booking status

- Add null/empty node validation in notification checks


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CarrierBookingNotificationDataPayloadRequestConformanceCheck.java</strong><dd><code>Skip validation for missing booking notification nodes</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

booking/src/main/java/org/dcsa/conformance/standards/booking/checks/CarrierBookingNotificationDataPayloadRequestConformanceCheck.java

<li>Removed conditional check for <code>expectedAmendedBookingStatus</code> when <br>creating amended booking validation<br> <li> Added null/empty node validation in <code>createFullNotificationChecksAt</code> <br>method<br> <li> Modified validation logic to skip checks when JSON nodes are missing <br>or empty


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/332/files#diff-81288fcaaccc29015550224c08b28b12371581d870bef2a366ca2331f41dfe38">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>