### PR TITLE
SD-2271: Implement changes to allow uc14 to be a or b

### DIFF
--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/BookingScenarioListBuilder.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/BookingScenarioListBuilder.java
@@ -102,14 +102,14 @@ class BookingScenarioListBuilder extends ScenarioListBuilder<BookingScenarioList
                                                                                         CANCELLATION_RECEIVED,
                                                                                         false)
                                                                                     .thenEither(
-                                                                                        uc14CarrierBookingCancellationConfirmed()
+                                                                                        uc14aCarrierBookingCancellationConfirmed()
                                                                                             .then(
                                                                                                 shipperGetBooking(
                                                                                                     CANCELLED,
                                                                                                     null,
                                                                                                     CANCELLATION_CONFIRMED,
                                                                                                     false)),
-                                                                                        uc14CarrierBookingCancellationDeclined()
+                                                                                        uc14bCarrierBookingCancellationDeclined()
                                                                                             .then(
                                                                                                 shipperGetBooking(
                                                                                                         CONFIRMED,
@@ -486,7 +486,7 @@ class BookingScenarioListBuilder extends ScenarioListBuilder<BookingScenarioList
                     BOOKING_NOTIFICATIONS_API, BOOKING_NOTIFICATION_SCHEMA_NAME)));
   }
 
-  private static BookingScenarioListBuilder uc14CarrierBookingCancellationConfirmed() {
+  private static BookingScenarioListBuilder uc14aCarrierBookingCancellationConfirmed() {
     return carrierStateChange(
         (carrierPartyName, shipperPartyName, previousAction, requestSchemaValidator) ->
             new UC14CarrierProcessBookingCancellationAction(
@@ -499,7 +499,7 @@ class BookingScenarioListBuilder extends ScenarioListBuilder<BookingScenarioList
                 true));
   }
 
-  private static BookingScenarioListBuilder uc14CarrierBookingCancellationDeclined() {
+  private static BookingScenarioListBuilder uc14bCarrierBookingCancellationDeclined() {
     return carrierStateChange(
         (carrierPartyName, shipperPartyName, previousAction, requestSchemaValidator) ->
             new UC14CarrierProcessBookingCancellationAction(

--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/action/UC14CarrierProcessBookingCancellationAction.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/action/UC14CarrierProcessBookingCancellationAction.java
@@ -25,7 +25,12 @@ public class UC14CarrierProcessBookingCancellationAction extends StateChangingBo
       BookingState expectedAmendedBookingStatus,
       JsonSchemaValidator requestSchemaValidator,
       boolean isCancellationConfirmed) {
-    super(carrierPartyName, shipperPartyName, previousAction, "UC14", 204);
+    super(
+        carrierPartyName,
+        shipperPartyName,
+        previousAction,
+        getFormattedActionTitle(isCancellationConfirmed),
+        204);
     this.requestSchemaValidator = requestSchemaValidator;
     this.isCancellationConfirmed = isCancellationConfirmed;
     this.expectedBookingStatus = expectedBookingStatus;
@@ -85,5 +90,10 @@ public class UC14CarrierProcessBookingCancellationAction extends StateChangingBo
                 requestSchemaValidator));
       }
     };
+  }
+
+  private static String getFormattedActionTitle(boolean isCancellationConfirmed) {
+    return "UC14%s [%s]"
+        .formatted(isCancellationConfirmed ? "a" : "b", isCancellationConfirmed ? "A" : "D");
   }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Rename UC14 methods to distinguish cancellation confirmed (UC14a) vs declined (UC14b)

- Update action title formatting to include 'a' or 'b' suffix with status indicators


___

### **Changes diagram**

```mermaid
flowchart LR
  UC13["UC13: Shipper Cancel Booking"] --> UC14a["UC14a: Carrier Confirm Cancellation"]
  UC13 --> UC14b["UC14b: Carrier Decline Cancellation"]
  UC14a --> BookingCancelled["Booking Status: CANCELLED"]
  UC14b --> BookingConfirmed["Booking Status: CONFIRMED"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BookingScenarioListBuilder.java</strong><dd><code>Rename UC14 methods to UC14a/UC14b variants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

booking/src/main/java/org/dcsa/conformance/standards/booking/BookingScenarioListBuilder.java

<li>Rename <code>uc14CarrierBookingCancellationConfirmed()</code> to <br><code>uc14aCarrierBookingCancellationConfirmed()</code><br> <li> Rename <code>uc14CarrierBookingCancellationDeclined()</code> to <br><code>uc14bCarrierBookingCancellationDeclined()</code><br> <li> Update method calls in scenario flow to use new naming convention


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/337/files#diff-33a49a9fbac7cffbd264450701cdfbd1da85127a6fb7251af839e00406bf57b7">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UC14CarrierProcessBookingCancellationAction.java</strong><dd><code>Add dynamic action title formatting for UC14 variants</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

booking/src/main/java/org/dcsa/conformance/standards/booking/action/UC14CarrierProcessBookingCancellationAction.java

<li>Replace hardcoded "UC14" action title with dynamic formatting method<br> <li> Add <code>getFormattedActionTitle()</code> method to generate "UC14a [A]" or "UC14b <br>[D]" titles<br> <li> Update constructor to use formatted action title based on cancellation <br>confirmation status


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/337/files#diff-dd5b4633f6f6d189d0dbf3e5effe51f78247d071783a6c6a2ec63c717240d257">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>