### PR TITLE
SD-2273-Wrong nesting of PartyContactDetails in SI fix

### DIFF
--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/party/EblShipper.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/party/EblShipper.java
@@ -3,6 +3,7 @@ package org.dcsa.conformance.standards.ebl.party;
 import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -127,18 +128,20 @@ public class EblShipper extends ConformanceParty {
     if (!scenarioType.isToOrder()) {
       // Cannot substitute this because it is a full element
       var parties = (ObjectNode) jsonRequestBody.path("documentParties");
-      parties
-          .putObject("consignee")
-          .put("partyName", "DCSA CTK Consignee")
-          .putArray("identifyingCodes")
-          .addObject()
-          .put("codeListProvider", "W3C")
-          .put("partyCode", "MSK")
-          .put("codeListName", "DID")
-          .putArray("partyContactDetails")
-          .addObject()
-          .put("name", "DCSA another test person")
-          .put("email", "no-reply@dcsa-consignee.example.org");
+
+      ObjectNode consignee = parties.putObject("consignee");
+      consignee.put("partyName", "DCSA CTK Consignee");
+
+      ArrayNode identifyingCodes = consignee.putArray("identifyingCodes");
+      ObjectNode idCode = identifyingCodes.addObject();
+      idCode.put("codeListProvider", "W3C");
+      idCode.put("partyCode", "MSK");
+      idCode.put("codeListName", "DID");
+
+      ArrayNode contactDetails = consignee.putArray("partyContactDetails");
+      ObjectNode contact = contactDetails.addObject();
+      contact.put("name", "DCSA another test person");
+      contact.put("email", "no-reply@dcsa-consignee.example.org");
     }
     if (scenarioType.transportDocumentTypeCode().equals("BOL")) {
       JsonNode documentParties = jsonRequestBody.path("documentParties");


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed incorrect nesting of `partyContactDetails` in consignee party structure

- Refactored JSON object construction to use proper hierarchical structure

- Added proper array handling for identifying codes and contact details


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Original Structure"] --> B["Refactored Structure"]
  B --> C["Consignee Object"]
  C --> D["Identifying Codes Array"]
  C --> E["Party Contact Details Array"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EblShipper.java</strong><dd><code>Fix consignee party structure nesting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl/src/main/java/org/dcsa/conformance/standards/ebl/party/EblShipper.java

<li>Added <code>ArrayNode</code> import for proper array handling<br> <li> Refactored consignee object construction from chained method calls to <br>step-by-step building<br> <li> Fixed nesting structure by creating separate objects for consignee, <br>identifying codes, and contact details<br> <li> Ensured <code>partyContactDetails</code> is properly nested under consignee rather <br>than identifying codes


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/343/files#diff-fe0bf3d1c7ba79cc3bf0c9389142fbae69d1ddd7ad4dd3c80058a4c2bbaefc78">+15/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>