### PR TITLE
SD-2331-Removed type code validation from vessel voyage

### DIFF
--- a/arrival-notice/src/main/java/org/dcsa/conformance/standards/an/checks/ANChecks.java
+++ b/arrival-notice/src/main/java/org/dcsa/conformance/standards/an/checks/ANChecks.java
@@ -238,7 +238,6 @@ public class ANChecks {
           issues.addAll(validatePortOfDischargePresence().validate(body));
           issues.addAll(validatePortOfDischargeLocation().validate(body));
           issues.addAll(validateVesselVoyagesArray().validate(body));
-          issues.addAll(validateVesselVoyageField("typeCode").validate(body));
           issues.addAll(validateVesselVoyageField("vesselName").validate(body));
           issues.addAll(validateVesselVoyageField("carrierVoyageNumber").validate(body));
           return issues;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed `typeCode` validation from vessel voyage checks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["validateTransport()"] --> B["Transport Validation Checks"]
  B --> C["ETA Validation"]
  B --> D["Port of Discharge Validation"]
  B --> E["Vessel Voyages Array Validation"]
  B --> F["Vessel Name Validation"]
  B --> G["Carrier Voyage Number Validation"]
  H["typeCode Validation"] -.-> B
  style H stroke-dasharray: 5 5
  style H fill:#ffcccc
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ANChecks.java</strong><dd><code>Remove typeCode validation from transport checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

arrival-notice/src/main/java/org/dcsa/conformance/standards/an/checks/ANChecks.java

<ul><li>Removed <code>validateVesselVoyageField("typeCode")</code> validation call from <br>transport validation method</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/356/files#diff-79386e5d990a285f1a98eb4ef0628874d1ac3a2c05b49c569162d791ee4152a8">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

