### PR TITLE
SD-2055-remove csp action from TD scenarios

### DIFF
--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/EblScenarioListBuilder.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/EblScenarioListBuilder.java
@@ -117,7 +117,7 @@ public class EblScenarioListBuilder extends ScenarioListBuilder<EblScenarioListB
                             .toArray(EblScenarioListBuilder[]::new))),
             Map.entry(
                 "Shipper interactions with transport document",
-                carrierSupplyScenarioParameters(ScenarioType.REGULAR_STRAIGHT_BL, isTd)
+                noAction()
                     .then(
                         uc6Get(
                             true,
@@ -222,10 +222,9 @@ public class EblScenarioListBuilder extends ScenarioListBuilder<EblScenarioListB
 
   private static EblScenarioListBuilder buildScenarioForType(ScenarioType type, boolean isTd) {
     if (type.isSWB()) {
-      return carrierSupplyScenarioParameters(type, isTd).then(uc6Get(true, uc7Get(uc8Get())));
+      return uc6Get(true, uc7Get(uc8Get()));
     }
-    return carrierSupplyScenarioParameters(type, isTd)
-        .then(uc6Get(true, uc7Get(uc8Get(uc12Get(uc13Get())))));
+    return uc6Get(true, uc7Get(uc8Get(uc12Get(uc13Get()))));
   }
 
   private static EblScenarioListBuilder uc3AndAllSiOnlyPathsFrom(

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/action/UC6_Carrier_PublishDraftTransportDocumentAction.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/action/UC6_Carrier_PublishDraftTransportDocumentAction.java
@@ -55,7 +55,6 @@ public class UC6_Carrier_PublishDraftTransportDocumentAction extends StateChangi
         dsp = dsp.withTransportDocumentReference(tdr.asText());
       }
     getDspConsumer().accept(dsp.withNewTransportDocumentContent(true));
-    getCarrierPayloadConsumer().accept(OBJECT_MAPPER.createObjectNode());
   }
 
   @Override
@@ -86,12 +85,10 @@ public class UC6_Carrier_PublishDraftTransportDocumentAction extends StateChangi
   public ObjectNode asJsonNode() {
     var dsp = getDspSupplier().get();
     var dr = dsp.transportDocumentReference() != null ? dsp.transportDocumentReference() : dsp.shippingInstructionsReference();
-    var node = super.asJsonNode()
-      .put("documentReference", dr)
-      .put("scenarioType", dsp.scenarioType().name())
-      .put("skipSI", skipSI);
-    node.set(CarrierSupplyPayloadAction.CARRIER_PAYLOAD, getCarrierPayloadSupplier().get());
-    return node;
+    return super.asJsonNode()
+        .put("documentReference", dr)
+        .put("scenarioType", dsp.scenarioType().name())
+        .put("skipSI", skipSI);
   }
 
   @Override

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/party/EblCarrier.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/party/EblCarrier.java
@@ -186,7 +186,8 @@ public class EblCarrier extends ConformanceParty {
     String documentReference;
     CarrierShippingInstructions si;
     if (skipSI) {
-      var jsonRequestBody = actionPrompt.get(CarrierSupplyPayloadAction.CARRIER_PAYLOAD);
+      var jsonRequestBody =
+          getEblPayload(ScenarioType.valueOf(actionPrompt.required(SCENARIO_TYPE).asText()));
       si =
           CarrierShippingInstructions.initializeFromShippingInstructionsRequest(
               (ObjectNode) jsonRequestBody, apiVersion);

--- a/ebl/src/main/resources/standards/ebl/instructions/prompt-carrier-uc6.md
+++ b/ebl/src/main/resources/standards/ebl/instructions/prompt-carrier-uc6.md
@@ -1,3 +1,3 @@
-Perform Use Case 6: Publish a draft transport document matching the scenario parameters given in the previous step and provide the transport document reference here.
+Perform Use Case 6: Publish a draft transport document and provide the transport document reference here.
 
 * Set the transport document status to `DRAFT`.


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove carrier supply payload action from TD scenarios

- Simplify scenario building by removing CSP dependencies

- Update UC6 action to generate payload internally

- Streamline transport document workflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TD Scenarios"] -- "remove CSP dependency" --> B["Simplified Workflow"]
  B -- "generate payload internally" --> C["UC6 Action"]
  C -- "publish draft TD" --> D["Transport Document"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EblScenarioListBuilder.java</strong><dd><code>Remove CSP from scenario builders</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl/src/main/java/org/dcsa/conformance/standards/ebl/EblScenarioListBuilder.java

<ul><li>Replace <code>carrierSupplyScenarioParameters()</code> calls with <code>noAction()</code> or <br>direct UC calls<br> <li> Remove CSP dependency from TD-only scenarios<br> <li> Simplify scenario building for both SWB and regular document types</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/366/files#diff-751eca38c323ca86f376d892835e8674afdab8619c8dfe574213fa6e506abade">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UC6_Carrier_PublishDraftTransportDocumentAction.java</strong><dd><code>Remove carrier payload handling from UC6</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl/src/main/java/org/dcsa/conformance/standards/ebl/action/UC6_Carrier_PublishDraftTransportDocumentAction.java

<ul><li>Remove carrier payload consumer call in <code>doHandleExchange()</code><br> <li> Remove carrier payload from JSON node serialization<br> <li> Clean up asJsonNode() method by removing payload handling</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/366/files#diff-b7c8c5107852bee7eb4edcef25368db0520555931ed92761f0fd3aa0775feeaa">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EblCarrier.java</strong><dd><code>Generate payload internally in carrier</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl/src/main/java/org/dcsa/conformance/standards/ebl/party/EblCarrier.java

<ul><li>Replace carrier payload retrieval with internal <code>getEblPayload()</code> call<br> <li> Generate payload directly using scenario type instead of external <br>input</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/366/files#diff-df929569c19c642da476e71c6207b1faee8a7c98900e850aeb2cb6a829ec11b3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prompt-carrier-uc6.md</strong><dd><code>Update UC6 instruction text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl/src/main/resources/standards/ebl/instructions/prompt-carrier-uc6.md

<ul><li>Remove reference to "scenario parameters given in the previous step"<br> <li> Simplify instruction text for UC6 prompt</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/366/files#diff-fb2616093bfa1f0b1af4ea543c4f207bd4040c1642a4553dc429919e09759007">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

