### PR TITLE
SD-2794: Remove empty or null fields from JSON files.

### DIFF
--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SurrenderRequestResponseAction.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SurrenderRequestResponseAction.java
@@ -136,11 +136,12 @@ public class SurrenderRequestResponseAction extends EblSurrenderAction {
                     JsonPointer.compile("/surrenderRequestCode"),
                     forAmendment ? "AREQ" : "SREQ"),
                 new JsonAttributeCheck(
-                    EblSurrenderRole::isPlatform,
-                    getMatchedExchangeUuid(),
-                    HttpMessageType.REQUEST,
-                    JsonPointer.compile("/reasonCode"),
-                    forAmendment && isSwitchToPaper ? "SWTP" : ""),
+                        EblSurrenderRole::isPlatform,
+                        getMatchedExchangeUuid(),
+                        HttpMessageType.REQUEST,
+                        JsonPointer.compile("/reasonCode"),
+                        "SWTP")
+                    .withRelevance(forAmendment && isSwitchToPaper),
                 surrenderRequestChecks(getMatchedExchangeUuid(), expectedApiVersion),
                 new JsonAttributeCheck(
                     EblSurrenderRole::isPlatform,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add automatic removal of empty or null fields from JSON nodes

- Implement recursive field cleanup in `JsonToolkit.templateFileToJsonNode()`

- Utilize new `JsonUtil.isMissingOrEmpty()` utility for field validation

- Refactor reasonCode check with conditional relevance in surrender action


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Template File"] -->|"IOToolkit.templateFileToText()"| B["JSON Text"]
  B -->|"OBJECT_MAPPER.readTree()"| C["JsonNode"]
  C -->|"removeEmptyOrNullFields()"| D["Cleaned JsonNode"]
  D -->|"Return"| E["Final Output"]
  F["JsonUtil.isMissingOrEmpty()"] -.->|"Validates fields"| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JsonToolkit.java</strong><dd><code>Add recursive empty field removal to JSON processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/src/main/java/org/dcsa/conformance/core/toolkit/JsonToolkit.java

<ul><li>Added import for <code>ObjectNode</code> and <code>JsonUtil</code> classes<br> <li> Modified <code>templateFileToJsonNode()</code> to call new <br><code>removeEmptyOrNullFields()</code> method<br> <li> Implemented recursive <code>removeEmptyOrNullFields()</code> method that removes <br>null/empty fields from objects and processes array elements<br> <li> Uses <code>JsonUtil.isMissingOrEmpty()</code> to identify fields for removal</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/450/files#diff-81a90c7fd2568dffae1fee527072b2e59fab39df7140b4537d5faeece20ce877">+28/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SurrenderRequestResponseAction.java</strong><dd><code>Refactor reasonCode validation with conditional relevance</code></dd></summary>
<hr>

ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SurrenderRequestResponseAction.java

<ul><li>Reformatted <code>JsonAttributeCheck</code> for reasonCode with improved <br>indentation<br> <li> Changed reasonCode expected value from conditional expression to fixed <br>"SWTP"<br> <li> Added <code>withRelevance()</code> method call to conditionally apply the check <br>based on amendment and switch-to-paper flags</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/450/files#diff-3cfaaf4b8c08bc0ef99e929afc4ee09ca8bbe12f92b65fa171e6fe66b7f9ae86">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

