### PR TITLE
SD-2551: Updated internal sandbox messages

### DIFF
--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/party/EblCarrier.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/party/EblCarrier.java
@@ -500,9 +500,12 @@ public class EblCarrier extends ConformanceParty {
       ConformanceResponse response =
           request.createResponse(
               200, Map.of(API_VERSION, List.of(apiVersion)), new ConformanceMessageBody(body));
+      String stateInfo = amendedContent
+          ? "(amended content, in state '%s')".formatted(si.getShippingInstructionsState().wireName())
+          : "(in state '%s')".formatted(si.getShippingInstructionsState().wireName());
       addOperatorLogEntry(
-          "Responded to GET shipping instructions request '%s' (in state '%s')"
-              .formatted(documentReference, si.getShippingInstructionsState().wireName()));
+          "Responded to GET shipping instructions request '%s' %s"
+              .formatted(documentReference, stateInfo));
       return response;
     }
     return return404(request, "The Shipping Instructions does not exist");
@@ -528,7 +531,7 @@ public class EblCarrier extends ConformanceParty {
             200, Map.of(API_VERSION, List.of(apiVersion)), new ConformanceMessageBody(body));
     addOperatorLogEntry(
         "Responded to GET transport document request '%s' (in state '%s')"
-            .formatted(documentReference, si.getShippingInstructionsState().wireName()));
+            .formatted(documentReference, si.getTransportDocumentState().wireName()));
     return response;
   }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed incorrect state reference in transport document response log

- Enhanced shipping instructions response log with amended content indicator

- Improved log message clarity for shipping instructions state tracking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GET Shipping Instructions"] -->|amended content| B["Enhanced log message"]
  A -->|normal content| B
  C["GET Transport Document"] -->|incorrect state| D["Fixed to use correct state"]
  B --> E["Improved operator logging"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EblCarrier.java</strong><dd><code>Fix state logging and enhance message clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl/src/main/java/org/dcsa/conformance/standards/ebl/party/EblCarrier.java

<ul><li>Fixed bug where transport document response logged shipping <br>instructions state instead of transport document state<br> <li> Enhanced shipping instructions response log to indicate when content <br>is amended<br> <li> Refactored log message formatting to use intermediate <code>stateInfo</code> <br>variable for clarity<br> <li> Improved operator log entries for better state tracking and debugging</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/453/files#diff-df929569c19c642da476e71c6207b1faee8a7c98900e850aeb2cb6a829ec11b3">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

