### PR TITLE
SD-2785-added cursor also to cs logs

### DIFF
--- a/commercial-schedules/src/main/java/org/dcsa/conformance/standards/cs/party/CsSubscriber.java
+++ b/commercial-schedules/src/main/java/org/dcsa/conformance/standards/cs/party/CsSubscriber.java
@@ -1,7 +1,6 @@
 package org.dcsa.conformance.standards.cs.party;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.*;
 import java.util.function.Consumer;
@@ -22,7 +21,6 @@ import org.dcsa.conformance.standards.cs.action.CsGetVesselSchedulesAction;
 @Slf4j
 public class CsSubscriber extends ConformanceParty {
   private static final String CURSOR = "cursor";
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   public CsSubscriber(
       String apiVersion,

--- a/commercial-schedules/src/main/java/org/dcsa/conformance/standards/cs/party/CsSubscriber.java
+++ b/commercial-schedules/src/main/java/org/dcsa/conformance/standards/cs/party/CsSubscriber.java
@@ -1,6 +1,5 @@
 package org.dcsa.conformance.standards.cs.party;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -115,22 +114,5 @@ public class CsSubscriber extends ConformanceParty {
     throw new UnsupportedOperationException();
   }
 
-  private String getParamsForLogging(Map<String, Collection<String>> queryParams) {
-    Map<String, String> flattenedParams = flattenQueryParams(queryParams);
-    return toPrettyJson(flattenedParams);
-  }
 
-  private Map<String, String> flattenQueryParams(Map<String, Collection<String>> queryParams) {
-
-    return queryParams.entrySet().stream()
-        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().iterator().next()));
-  }
-
-  private String toPrettyJson(Map<String, String> map) {
-    try {
-      return OBJECT_MAPPER.writeValueAsString(map);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException("Failed to serialize query params", e);
-    }
-  }
 }

--- a/core/src/main/java/org/dcsa/conformance/core/party/ConformanceParty.java
+++ b/core/src/main/java/org/dcsa/conformance/core/party/ConformanceParty.java
@@ -2,6 +2,7 @@ package org.dcsa.conformance.core.party;
 
 import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -398,5 +399,24 @@ public abstract class ConformanceParty implements StatefulEntity {
         statusCode,
         Map.of(API_VERSION, List.of(apiVersion)),
         new ConformanceMessageBody(OBJECT_MAPPER.createObjectNode().put("message", message)));
+  }
+
+  protected String getParamsForLogging(Map<String, Collection<String>> queryParams) {
+    Map<String, String> flattenedParams = flattenQueryParams(queryParams);
+    return toPrettyJson(flattenedParams);
+  }
+
+  private Map<String, String> flattenQueryParams(Map<String, Collection<String>> queryParams) {
+
+    return queryParams.entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().iterator().next()));
+  }
+
+  private String toPrettyJson(Map<String, String> map) {
+    try {
+      return OBJECT_MAPPER.writeValueAsString(map);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize query params", e);
+    }
   }
 }


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add cursor parameter to Commercial Schedules logs

- Replace SSP JSON logging with actual query parameters

- Implement helper methods for parameter serialization

- Add ObjectMapper for JSON serialization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Query Parameters"] -->|"flatten"| B["Flattened Map"]
  B -->|"serialize to JSON"| C["Pretty JSON String"]
  C -->|"log"| D["Operator Log Entry"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CsSubscriber.java</strong><dd><code>Add cursor parameter logging with JSON serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

commercial-schedules/src/main/java/org/dcsa/conformance/standards/cs/party/CsSubscriber.java

<ul><li>Added imports for <code>JsonProcessingException</code> and <code>ObjectMapper</code><br> <li> Added static <code>OBJECT_MAPPER</code> field for JSON serialization<br> <li> Updated three methods (<code>getVesselSchedules</code>, <code>getPortSchedules</code>, <br><code>getPointToPointRoutings</code>) to log actual query parameters instead of SSP <br>JSON<br> <li> Implemented three new helper methods: <code>getParamsForLogging()</code>, <br><code>flattenQueryParams()</code>, and <code>toPrettyJson()</code> to serialize and format query <br>parameters for logging</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/454/files#diff-63f35a7ddc483623612eb53bedcca4c944ec7268feb54b4104d034c780f50f8c">+26/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

