### PR TITLE
Sd 2787 remove lightweight from notification log

### DIFF
--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/party/BookingShipper.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/party/BookingShipper.java
@@ -190,7 +190,7 @@ public class BookingShipper extends ConformanceParty {
             new ConformanceMessageBody(OBJECT_MAPPER.createObjectNode()));
 
     addOperatorLogEntry(
-        "Handled lightweight notification: %s".formatted(request.message().body().getJsonBody()));
+        "Handled notification: %s".formatted(request.message().body().getJsonBody()));
     return response;
   }
 

--- a/booking/src/main/java/org/dcsa/conformance/standards/booking/party/BookingShipper.java
+++ b/booking/src/main/java/org/dcsa/conformance/standards/booking/party/BookingShipper.java
@@ -100,13 +100,15 @@ public class BookingShipper extends ConformanceParty {
 
     ConformanceResponse conformanceResponse = syncCounterpartPost("/v2/bookings", bookingPayload);
 
+    addOperatorLogEntry("Sent a booking request with the parameters: %s".formatted(bookingPayload));
+
     JsonNode jsonBody = conformanceResponse.message().body().getJsonBody();
     String cbrr = jsonBody.path("carrierBookingRequestReference").asText();
     ObjectNode updatedBooking =
         ((ObjectNode) bookingPayload).put("carrierBookingRequestReference", cbrr);
     persistentMap.save(cbrr, updatedBooking);
 
-    addOperatorLogEntry("Sent a booking request with the parameters: %s".formatted(bookingPayload));
+
   }
 
   private void sendCancelBookingRequest(JsonNode actionPrompt) {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed "lightweight" terminology from notification log message

- Repositioned operator log entry to execute before response processing

- Improved logging clarity by using generic "notification" terminology


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Notification Handler"] -- "logs notification event" --> B["Updated Log Message"]
  C["Booking Request"] -- "logs with repositioned entry" --> D["Improved Log Timing"]
  B -- "removed lightweight term" --> E["Generic notification text"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BookingShipper.java</strong><dd><code>Remove lightweight term and reposition logging calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

booking/src/main/java/org/dcsa/conformance/standards/booking/party/BookingShipper.java

<ul><li>Removed "lightweight" descriptor from notification log message in <br><code>handleRequest()</code> method<br> <li> Moved <code>addOperatorLogEntry()</code> call in <code>sendBookingRequest()</code> to execute <br>before response processing<br> <li> Changed log text from "Handled lightweight notification" to "Handled <br>notification"<br> <li> Improved code organization by repositioning logging statement for <br>better execution flow</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/455/files#diff-5329e13f27f5d11f330bd70f1e1e92e943ddfc85423899c636ac31690a9f91a2">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

