### PR TITLE
SD-2811-remove the check that is not needed

### DIFF
--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SurrenderRequestResponseAction.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SurrenderRequestResponseAction.java
@@ -142,15 +142,7 @@ public class SurrenderRequestResponseAction extends EblSurrenderAction {
                         JsonPointer.compile("/reasonCode"),
                         "SWTP")
                     .withRelevance(forAmendment && isSwitchToPaper),
-                surrenderRequestChecks(getMatchedExchangeUuid(), expectedApiVersion),
-                new JsonAttributeCheck(
-                    EblSurrenderRole::isPlatform,
-                    getMatchedExchangeUuid(),
-                    HttpMessageType.REQUEST,
-                    JsonPointer.compile("/transportDocumentReference"),
-                    sspSupplier.get() == null
-                        ? null
-                        : sspSupplier.get().transportDocumentReference())),
+                surrenderRequestChecks(getMatchedExchangeUuid(), expectedApiVersion)),
             Stream.of(
                 new UrlPathCheck(
                     "[Response]",


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove unnecessary validation check for transportDocumentReference

- Simplifies surrender request response validation logic

- Eliminates redundant JSON attribute validation in request processing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SurrenderRequestResponseAction"] -->|removes| B["JsonAttributeCheck for transportDocumentReference"]
  B -->|eliminates| C["Redundant validation logic"]
  A -->|retains| D["surrenderRequestChecks call"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SurrenderRequestResponseAction.java</strong><dd><code>Remove transportDocumentReference validation check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SurrenderRequestResponseAction.java

<ul><li>Removed JsonAttributeCheck validation for <code>/transportDocumentReference</code> <br>field<br> <li> Removed conditional logic checking <br><code>sspSupplier.get().transportDocumentReference()</code><br> <li> Retained the <code>surrenderRequestChecks()</code> method call for other <br>validations<br> <li> Simplified the stream of conformance checks in <code>createSubChecks()</code> <br>method</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/457/files#diff-3cfaaf4b8c08bc0ef99e929afc4ee09ca8bbe12f92b65fa171e6fe66b7f9ae86">+1/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

