### PR TITLE
SD-2810-reasonCode validation corrected

### DIFF
--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SurrenderRequestResponseAction.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SurrenderRequestResponseAction.java
@@ -135,13 +135,6 @@ public class SurrenderRequestResponseAction extends EblSurrenderAction {
                     HttpMessageType.REQUEST,
                     JsonPointer.compile("/surrenderRequestCode"),
                     forAmendment ? "AREQ" : "SREQ"),
-                new JsonAttributeCheck(
-                        EblSurrenderRole::isPlatform,
-                        getMatchedExchangeUuid(),
-                        HttpMessageType.REQUEST,
-                        JsonPointer.compile("/reasonCode"),
-                        "SWTP")
-                    .withRelevance(forAmendment && isSwitchToPaper),
                 surrenderRequestChecks(getMatchedExchangeUuid(), expectedApiVersion)),
             Stream.of(
                 new UrlPathCheck(

--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/checks/SurrenderChecks.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/checks/SurrenderChecks.java
@@ -1,6 +1,7 @@
 package org.dcsa.conformance.standards.eblsurrender.checks;
 
 import static org.dcsa.conformance.standards.ebl.checks.EblDatasets.DOCUMENTATION_PARTY_CODE_LIST_PROVIDER_CODES;
+import static org.dcsa.conformance.standards.ebl.checks.EblDatasets.REASON_CODES;
 
 import java.util.UUID;
 import lombok.experimental.UtilityClass;
@@ -22,6 +23,7 @@ public class SurrenderChecks {
   private static final String ENDORSEMENT_CHAIN = "endorsementChain";
   private static final String ACTION_CODE = "actionCode";
   private static final String CODE_LIST_PROVIDER = "codeListProvider";
+  private static final String REASON_CODE = "reasonCode";
   private static final String ACTOR = "actor";
   private static final String IDENTIFYING_CODES = "identifyingCodes";
   private static final String RECIPIENT = "recipient";
@@ -49,6 +51,12 @@ public class SurrenderChecks {
           JsonAttribute.matchedMustBeDatasetKeywordIfPresent(
               DOCUMENTATION_PARTY_CODE_LIST_PROVIDER_CODES));
 
+  private static final JsonRebasableContentCheck REASON_CODE_CHECK =
+      JsonAttribute.allIndividualMatchesMustBeValid(
+          "Validate '%s' (if present) is a known value".formatted(REASON_CODE),
+          mav -> mav.submitAllMatching(REASON_CODE),
+          JsonAttribute.matchedMustBeDatasetKeywordIfPresent(REASON_CODES));
+
   public static ActionCheck surrenderRequestChecks(UUID matched, String standardVersion) {
     return JsonAttribute.contentChecks(
         EblSurrenderRole::isPlatform,
@@ -56,6 +64,7 @@ public class SurrenderChecks {
         HttpMessageType.REQUEST,
         standardVersion,
         SURRENDER_ACTION_VALIDATION,
-        SURRENDER_PARTY_CODE_LIST_PROVIDER);
+        SURRENDER_PARTY_CODE_LIST_PROVIDER,
+        REASON_CODE_CHECK);
   }
 }

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EblDatasets.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EblDatasets.java
@@ -45,6 +45,9 @@ public class EblDatasets {
           "WAVE", "CARX", "ESSD", "IDT", "BOLE", "EDOX", "IQAX", "SECR", "TRGO", "ETEU", "TRAC",
           "BRIT", "GSBN", "WISE", "GLEIF", "W3C", "DNB", "FMC", "DCSA", "ZZZ");
 
+  public static final KeywordDataset REASON_CODES =
+      KeywordDataset.staticDataset("SWTP", "COD", "SWI");
+
   public static final KeywordDataset REQUESTED_CARRIER_CLAUSES_SET =
       KeywordDataset.staticDataset(
           "CARGO_CARGOSPECIFICS",


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Moved `reasonCode` validation from hardcoded check to reusable dataset-based validation

- Added `REASON_CODES` dataset with valid values: SWTP, COD, SWI

- Integrated `reasonCode` validation into `surrenderRequestChecks` method

- Removed incorrect relevance condition that limited validation to amendment scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded reasonCode check<br/>with SWTP only"] -->|Remove| B["Dataset-based validation"]
  C["New REASON_CODES dataset<br/>SWTP, COD, SWI"] -->|Add| B
  B -->|Integrate| D["surrenderRequestChecks method"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SurrenderRequestResponseAction.java</strong><dd><code>Remove hardcoded reasonCode validation check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SurrenderRequestResponseAction.java

<ul><li>Removed hardcoded <code>reasonCode</code> validation check with SWTP value<br> <li> Removed incorrect relevance condition tied to amendment and <br>switch-to-paper flags<br> <li> Validation now delegated to centralized <code>surrenderRequestChecks</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/459/files#diff-3cfaaf4b8c08bc0ef99e929afc4ee09ca8bbe12f92b65fa171e6fe66b7f9ae86">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SurrenderChecks.java</strong><dd><code>Add dataset-based reasonCode validation check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/checks/SurrenderChecks.java

<ul><li>Added import for <code>REASON_CODES</code> dataset from EblDatasets<br> <li> Added <code>REASON_CODE</code> constant for field name<br> <li> Created new <code>REASON_CODE_CHECK</code> using dataset-based validation<br> <li> Integrated <code>REASON_CODE_CHECK</code> into <code>surrenderRequestChecks</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/459/files#diff-69ba8aefdb8bbe7606b1089ca9fc2475a1ab4b3163b576c12d55bbe417800dd0">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EblDatasets.java</strong><dd><code>Define REASON_CODES dataset with valid values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EblDatasets.java

<ul><li>Added new <code>REASON_CODES</code> dataset with three valid values: SWTP, COD, SWI<br> <li> Provides centralized source of truth for reason code validation</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/459/files#diff-cf98df85588aa7b9a52011751dbb93ad55da645327edf82e93832b773104f0fa">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

