### PR TITLE
Comment github action code that generates report because we still dont have the IAM policy to do that

### DIFF
--- a/.github/workflows/deploy-to-test-or-dt.yml
+++ b/.github/workflows/deploy-to-test-or-dt.yml
@@ -92,24 +92,24 @@ jobs:
           cd cdk/
           cdk diff ${{ env.AWS_ENVIRONMENT }}ConformanceStack
 
-      - name: Create pre-deployment reports in all sandboxes
-        run: |
-          echo "Creating report in all sandboxes before deployment..."
-          REPORT_TITLE="Before DCSA deployment - $(date '+%Y-%m-%d %H:%M:%S UTC')"
-          PAYLOAD=$(jq -n \
-            --arg operation "createReportInAllSandboxes" \
-            --arg reportTitle "$REPORT_TITLE" \
-            '{operation: $operation, reportTitle: $reportTitle}')
-
-          aws lambda invoke \
-            --function-name ${{ env.AWS_ENVIRONMENT }}AdminLambda \
-            --payload "$PAYLOAD" \
-            --cli-binary-format raw-in-base64-out \
-            response.json
-
-          echo "Lambda response:"
-          cat response.json | jq '.'
-          rm response.json
+#      - name: Create pre-deployment reports in all sandboxes
+#        run: |
+#          echo "Creating report in all sandboxes before deployment..."
+#          REPORT_TITLE="Before DCSA deployment - $(date '+%Y-%m-%d %H:%M:%S UTC')"
+#          PAYLOAD=$(jq -n \
+#            --arg operation "createReportInAllSandboxes" \
+#            --arg reportTitle "$REPORT_TITLE" \
+#            '{operation: $operation, reportTitle: $reportTitle}')
+#
+#          aws lambda invoke \
+#            --function-name ${{ env.AWS_ENVIRONMENT }}AdminLambda \
+#            --payload "$PAYLOAD" \
+#            --cli-binary-format raw-in-base64-out \
+#            response.json
+#
+#          echo "Lambda response:"
+#          cat response.json | jq '.'
+#          rm response.json
 
       - name: Deploy Conformance-Gateway Stack to ${{ env.AWS_ENVIRONMENT }}
         run: |


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Comment out pre-deployment report generation step in GitHub Actions workflow

- Temporarily disable Lambda invocation for sandbox report creation

- Reason: Missing IAM policy permissions for report generation operation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Actions Workflow"] -->|"Commented Out"| B["Create Reports Lambda Step"]
  B -->|"Blocked By"| C["Missing IAM Policy"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy-to-test-or-dt.yml</strong><dd><code>Comment out Lambda report generation step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy-to-test-or-dt.yml

<ul><li>Commented out the entire 'Create pre-deployment reports in all <br>sandboxes' step<br> <li> Step included Lambda invocation with jq payload construction and <br>response handling<br> <li> Disabled due to insufficient IAM policy permissions for report <br>generation operation<br> <li> All 23 lines of the step converted to comments with '#' prefix</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/467/files#diff-cf59f3a5bd10e1dfe21d0f693712dcf0dacd037e46ffa22891e73f877a754f32">+18/-18</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

