### PR TITLE
SD-2887: Added kid to JWS in issuance when signing payloads as a synthetic carrier

### DIFF
--- a/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/action/PlatformScenarioParametersAction.java
+++ b/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/action/PlatformScenarioParametersAction.java
@@ -68,7 +68,9 @@ public class PlatformScenarioParametersAction extends IssuanceAction {
             "RESPONSE_CODE",
             responseCode.standardCode,
             "PUBLIC_KEY",
-            EblIssuanceCarrier.getCarrierPublicKey()),
+            EblIssuanceCarrier.getCarrierPublicKey(),
+            "KEY_ID",
+            EblIssuanceCarrier.getCarrierKeyId()),
         "prompt-platform-psp.md");
   }
 

--- a/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/party/EblIssuanceCarrier.java
+++ b/ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/party/EblIssuanceCarrier.java
@@ -306,4 +306,8 @@ public class EblIssuanceCarrier extends ConformanceParty {
   public static String getCarrierPublicKey() {
     return PAYLOAD_SIGNER.getPublicKeyInPemFormat();
   }
+
+  public static String getCarrierKeyId() {
+    return PAYLOAD_SIGNER.getKeyId();
+  }
 }

--- a/ebl-issuance/src/main/resources/standards/eblissuance/instructions/prompt-platform-psp.md
+++ b/ebl-issuance/src/main/resources/standards/eblissuance/instructions/prompt-platform-psp.md
@@ -22,7 +22,12 @@ The DCSA synthetic carrier will sign all issuance request payloads using JWS (JS
 PUBLIC_KEY
 ```
 
-**Note:** The synthetic carrier will use **PS256** (RSA-PSS with SHA-256) for signing. However, your platform could support all standard JWS algorithms for RSA (RS256/384/512, PS256/384/512) and ECDSA (ES256/384/512) key types to ensure broader compatibility.
+**Key ID (kid):** The JWS header will include a `kid` parameter with the value: **`KEY_ID`**. If your platform manages keys
+from multiple carriers, use this `kid` to identify which public key to use for signature verification.
+
+**Note:** The synthetic carrier will use **PS256** (RSA-PSS with SHA-256) for signing. However, your platform could
+support all standard JWS algorithms for RSA (RS256/384/512, PS256/384/512) and ECDSA (ES256/384/512) key types to ensure
+broader compatibility.
 
 ### 2. Scenario Parameters
 

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/JWSSignerDetails.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/JWSSignerDetails.java
@@ -3,4 +3,4 @@ package org.dcsa.conformance.standards.ebl.crypto;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSSigner;
 
-public record JWSSignerDetails(JWSAlgorithm algorithm, JWSSigner signer) {}
+public record JWSSignerDetails(JWSAlgorithm algorithm, JWSSigner signer, String keyId) {}

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/PayloadSignerFactory.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/PayloadSignerFactory.java
@@ -13,6 +13,7 @@ import java.io.StringWriter;
 import java.math.BigInteger;
 import java.security.KeyFactory;
 import java.security.KeyPair;
+import java.security.MessageDigest;
 import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.cert.CertificateFactory;
@@ -151,9 +152,20 @@ public class PayloadSignerFactory {
     return CTK_SENDER_INCORRECT_KEY_PAYLOAD_SIGNER;
   }
 
+  @SneakyThrows
+  private static String generateKeyId(PublicKey publicKey) {
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    byte[] hash = digest.digest(publicKey.getEncoded());
+    String base64 = Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+    return base64.substring(0, Math.min(8, base64.length()));
+  }
+
   private static PayloadSignerWithKey rsaBasedPayloadSigner(KeyPair keyPair) {
     return new X509BackedPayloadSigner(
-        new JWSSignerDetails(JWSAlgorithm.PS256, new RSASSASigner(keyPair.getPrivate())),
+        new JWSSignerDetails(
+            JWSAlgorithm.PS256,
+            new RSASSASigner(keyPair.getPrivate()),
+            generateKeyId(keyPair.getPublic())),
         generateSelfSignedCertificateSecret(keyPair));
   }
 
@@ -161,7 +173,9 @@ public class PayloadSignerFactory {
   private static PayloadSignerWithKey ecBasedPayloadSigner(KeyPair keyPair) {
     return new X509BackedPayloadSigner(
         new JWSSignerDetails(
-            JWSAlgorithm.ES256, new ECDSASigner((ECPrivateKey) keyPair.getPrivate())),
+            JWSAlgorithm.ES256,
+            new ECDSASigner((ECPrivateKey) keyPair.getPrivate()),
+            generateKeyId(keyPair.getPublic())),
         generateSelfSignedCertificateSecret(keyPair));
   }
 

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/PayloadSignerFactory.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/PayloadSignerFactory.java
@@ -157,7 +157,7 @@ public class PayloadSignerFactory {
     MessageDigest digest = MessageDigest.getInstance("SHA-256");
     byte[] hash = digest.digest(publicKey.getEncoded());
     String base64 = Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
-    return base64.substring(0, Math.min(8, base64.length()));
+    return base64;
   }
 
   private static PayloadSignerWithKey rsaBasedPayloadSigner(KeyPair keyPair) {

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/PayloadSignerWithKey.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/PayloadSignerWithKey.java
@@ -2,4 +2,6 @@ package org.dcsa.conformance.standards.ebl.crypto;
 
 public interface PayloadSignerWithKey extends PayloadSigner {
   String getPublicKeyInPemFormat();
+
+  String getKeyId();
 }

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/impl/DefaultPayloadSigner.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/impl/DefaultPayloadSigner.java
@@ -15,7 +15,9 @@ public class DefaultPayloadSigner implements PayloadSigner {
 
   @SneakyThrows
   public String sign(String payload) {
-    JWSHeader header = new JWSHeader.Builder(jwsSignerDetails.algorithm()).build();
+    JWSHeader header = new JWSHeader.Builder(jwsSignerDetails.algorithm())
+            .keyID(jwsSignerDetails.keyId())
+            .build();
     JWSObject jwsObject = new JWSObject(header, new Payload(payload));
     jwsObject.sign(jwsSignerDetails.signer());
     return jwsObject.serialize();

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/impl/X509BackedPayloadSigner.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/impl/X509BackedPayloadSigner.java
@@ -9,14 +9,22 @@ import org.dcsa.conformance.standards.ebl.crypto.PayloadSignerWithKey;
 public class X509BackedPayloadSigner extends DefaultPayloadSigner implements PayloadSignerWithKey {
 
   private final X509CertificateHolder x509Cert;
+  private final String keyId;
 
-  public X509BackedPayloadSigner(JWSSignerDetails jwsSignerDetails, X509CertificateHolder x509Cert) {
+  public X509BackedPayloadSigner(
+      JWSSignerDetails jwsSignerDetails, X509CertificateHolder x509Cert) {
     super(jwsSignerDetails);
     this.x509Cert = x509Cert;
+    this.keyId = jwsSignerDetails.keyId();
   }
 
   @Override
   public String getPublicKeyInPemFormat() {
     return pemEncodeCertificate(this.x509Cert);
+  }
+
+  @Override
+  public String getKeyId() {
+    return keyId;
   }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add `kid` (Key ID) parameter to JWS header for signature verification

- Generate SHA-256 based key ID from public key in PayloadSignerFactory

- Update JWSSignerDetails record to include keyId field

- Implement getKeyId() method in PayloadSignerWithKey interface

- Update documentation with KEY_ID parameter details


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PayloadSignerFactory"] -->|"generates keyId from public key"| B["JWSSignerDetails"]
  B -->|"includes keyId"| C["DefaultPayloadSigner"]
  C -->|"adds kid to JWS header"| D["JWS Token"]
  E["X509BackedPayloadSigner"] -->|"implements getKeyId()"| F["PayloadSignerWithKey"]
  F -->|"provides keyId to platform"| G["Platform Verification"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JWSSignerDetails.java</strong><dd><code>Add keyId field to JWSSignerDetails record</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/JWSSignerDetails.java

<ul><li>Added <code>String keyId</code> field to the JWSSignerDetails record<br> <li> Record now stores algorithm, signer, and key ID for JWS operations</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/476/files#diff-f0ac4add881db35498c9083104848d942debd4b3689394fab55161fafcef0dc4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PayloadSignerFactory.java</strong><dd><code>Generate and pass keyId to JWSSignerDetails constructors</code>&nbsp; </dd></summary>
<hr>

ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/PayloadSignerFactory.java

<ul><li>Added <code>generateKeyId()</code> method that creates SHA-256 hash of public key<br> <li> Method encodes hash as base64 URL-safe string and returns first 8 <br>characters<br> <li> Updated <code>rsaBasedPayloadSigner()</code> to pass generated keyId to <br>JWSSignerDetails<br> <li> Updated <code>ecBasedPayloadSigner()</code> to pass generated keyId to <br>JWSSignerDetails<br> <li> Added MessageDigest import for SHA-256 hashing</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/476/files#diff-840712e24423bf01b51a9feafd596de117537eb171181d3395e5b16179fe794f">+16/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PayloadSignerWithKey.java</strong><dd><code>Add getKeyId method to interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/PayloadSignerWithKey.java

<ul><li>Added <code>getKeyId()</code> method to the PayloadSignerWithKey interface<br> <li> Allows implementations to expose the key ID for verification purposes</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/476/files#diff-36b41d7a5715380347e56835e596c46f544aaec5460df131d3f201322d595a06">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DefaultPayloadSigner.java</strong><dd><code>Add kid parameter to JWS header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/impl/DefaultPayloadSigner.java

<ul><li>Modified <code>sign()</code> method to add <code>kid</code> parameter to JWS header<br> <li> Uses <code>keyID()</code> builder method to set the key ID from JWSSignerDetails</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/476/files#diff-a273881983a4c2cbc28f304becf820f55b29fd448a1b60218443c569ca4b994f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>X509BackedPayloadSigner.java</strong><dd><code>Implement getKeyId method and store keyId</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/impl/X509BackedPayloadSigner.java

<ul><li>Added <code>keyId</code> field to store the key ID from JWSSignerDetails<br> <li> Implemented <code>getKeyId()</code> method to return the stored key ID<br> <li> Updated constructor to extract and store keyId from JWSSignerDetails</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/476/files#diff-0b377af0727fa0f14a1889416e30f5a294de3ecead4276a4cb9298a07b6ea152">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EblIssuanceCarrier.java</strong><dd><code>Add getCarrierKeyId static method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/party/EblIssuanceCarrier.java

<ul><li>Added <code>getCarrierKeyId()</code> static method to expose the carrier's key ID<br> <li> Method retrieves key ID from PAYLOAD_SIGNER instance</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/476/files#diff-106a9b2ec30afd60dfad3e7fd692ef5a0f3644971716a0329e476a0dc1a48593">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PlatformScenarioParametersAction.java</strong><dd><code>Add KEY_ID to scenario parameters prompt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl-issuance/src/main/java/org/dcsa/conformance/standards/eblissuance/action/PlatformScenarioParametersAction.java

<ul><li>Added <code>KEY_ID</code> parameter to the human-readable prompt map<br> <li> Calls <code>EblIssuanceCarrier.getCarrierKeyId()</code> to retrieve the key ID <br>value</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/476/files#diff-4368b594e35e23ae7b2fb5d2adb3b0826198d2d89c975ff4019709dd0abf0bcc">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prompt-platform-psp.md</strong><dd><code>Document kid parameter and KEY_ID usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl-issuance/src/main/resources/standards/eblissuance/instructions/prompt-platform-psp.md

<ul><li>Added new section explaining the <code>kid</code> parameter in JWS header<br> <li> Documents that KEY_ID value is used for multi-carrier key <br>identification<br> <li> Reformatted existing note about PS256 algorithm for better readability</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/476/files#diff-07415ae2c7142d6b0d94da17a6b581af3f1539d2d5781d4d47c32025e7e411f5">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

