### PR TITLE
SD-2901: Implemented new method to generate certificates without variables so it stays consistent

### DIFF
--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/PayloadSignerFactory.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/PayloadSignerFactory.java
@@ -166,7 +166,7 @@ public class PayloadSignerFactory {
             JWSAlgorithm.PS256,
             new RSASSASigner(keyPair.getPrivate()),
             generateKeyId(keyPair.getPublic())),
-        generateSelfSignedCertificateSecret(keyPair));
+        generateStaticSelfSignedCertificate(keyPair));
   }
 
   @SneakyThrows
@@ -176,7 +176,7 @@ public class PayloadSignerFactory {
             JWSAlgorithm.ES256,
             new ECDSASigner((ECPrivateKey) keyPair.getPrivate()),
             generateKeyId(keyPair.getPublic())),
-        generateSelfSignedCertificateSecret(keyPair));
+        generateStaticSelfSignedCertificate(keyPair));
   }
 
   @SneakyThrows
@@ -273,18 +273,42 @@ public class PayloadSignerFactory {
     return w.getBuffer().toString();
   }
 
-  private static X509CertificateHolder generateSelfSignedCertificateSecret(KeyPair keyPair) {
-    X500Principal subject = new X500Principal("CN=DCSA-Conformance-Framework");
+  private static X509CertificateHolder generateStaticSelfSignedCertificate(KeyPair keyPair) {
+    // Fixed dates for consistent certificate generation
+    // Valid from: 2026-02-24 00:00:00 UTC (yesterday)
+    // Valid until: 2056-02-24 00:00:00 UTC (30 years ahead)
+    long notBefore = 1771977600000L;
+    long notAfter = 2718748800000L;
 
+    // Use a deterministic serial number derived from the public key
+    // This ensures the same key pair always produces the same serial number
+    byte[] publicKeyBytes = keyPair.getPublic().getEncoded();
+    BigInteger serialNumber = new BigInteger(1, publicKeyBytes).abs();
+
+    return buildCertificate(keyPair, notBefore, notAfter, serialNumber);
+  }
+
+  @SuppressWarnings("unused")
+  private static X509CertificateHolder generateSelfSignedCertificateSecret(KeyPair keyPair) {
     long notBefore = System.currentTimeMillis();
-    // 2500 days (several) years should be sufficient.
+    // 2500 days (several years) should be sufficient.
     long notAfter = notBefore + (1000L * 3600L * 24 * 2500);
+
     byte[] serialBytes = new byte[16];
     SECURE_RANDOM.nextBytes(serialBytes);
+    BigInteger serialNumber = new BigInteger(serialBytes);
+
+    return buildCertificate(keyPair, notBefore, notAfter, serialNumber);
+  }
+
+  private static X509CertificateHolder buildCertificate(
+      KeyPair keyPair, long notBefore, long notAfter, BigInteger serialNumber) {
+    X500Principal subject = new X500Principal("CN=DCSA-Conformance-Framework");
+
     X509v3CertificateBuilder certBuilder =
         new JcaX509v3CertificateBuilder(
             subject,
-            new BigInteger(serialBytes),
+            serialNumber,
             new Date(notBefore),
             new Date(notAfter),
             subject,
@@ -307,7 +331,7 @@ public class PayloadSignerFactory {
       return certBuilder.build(signer);
     } catch (Exception e) {
       throw new UserFacingException(
-          "Error while generating a self-certificate: " + e.getMessage(), e);
+          "Error while generating a self-signed certificate: " + e.getMessage(), e);
     }
   }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduced new static certificate generation method with fixed dates

- Deterministic serial numbers derived from public key for consistency

- Refactored certificate building logic into shared utility method

- Marked old dynamic certificate method as deprecated/unused


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["KeyPair"] -->|"rsaBasedPayloadSigner"| B["generateStaticSelfSignedCertificate"]
  A -->|"ecBasedPayloadSigner"| B
  B -->|"fixed dates & deterministic serial"| C["buildCertificate"]
  C -->|"X509CertificateHolder"| D["X509BackedPayloadSigner"]
  E["generateSelfSignedCertificateSecret"] -->|"deprecated"| F["marked unused"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PayloadSignerFactory.java</strong><dd><code>Implement static certificate generation for consistency</code>&nbsp; &nbsp; </dd></summary>
<hr>

ebl/src/main/java/org/dcsa/conformance/standards/ebl/crypto/PayloadSignerFactory.java

<ul><li>Replaced dynamic certificate generation with static method using fixed <br>dates (2026-2056)<br> <li> Implemented deterministic serial number generation from public key <br>bytes<br> <li> Extracted common certificate building logic into new <code>buildCertificate</code> <br>utility method<br> <li> Marked old <code>generateSelfSignedCertificateSecret</code> method as unused with <br><code>@SuppressWarnings</code><br> <li> Fixed typo in error message from "self-certificate" to "self-signed <br>certificate"</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/486/files#diff-840712e24423bf01b51a9feafd596de117537eb171181d3395e5b16179fe794f">+31/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

