### PR TITLE
SD-2904- Updated dataset values to latest version

### DIFF
--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/checks/SurrenderChecks.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/checks/SurrenderChecks.java
@@ -1,7 +1,8 @@
 package org.dcsa.conformance.standards.eblsurrender.checks;
 
-import static org.dcsa.conformance.standards.ebl.checks.EblDatasets.DOCUMENTATION_PARTY_CODE_LIST_PROVIDER_CODES;
 import static org.dcsa.conformance.standards.ebl.checks.EblDatasets.REASON_CODES;
+import static org.dcsa.conformance.standards.ebl.checks.EblDatasets.SURRENDER_ACTIONS_DATA_SET;
+import static org.dcsa.conformance.standards.ebl.checks.EblDatasets.SURRENDER_DOCUMENTATION_PARTY_CODE_LIST_PROVIDER_CODES;
 
 import java.util.UUID;
 import lombok.experimental.UtilityClass;
@@ -9,16 +10,11 @@ import org.dcsa.conformance.core.check.ActionCheck;
 import org.dcsa.conformance.core.check.JsonAttribute;
 import org.dcsa.conformance.core.check.JsonContentCheck;
 import org.dcsa.conformance.core.check.JsonRebasableContentCheck;
-import org.dcsa.conformance.core.check.KeywordDataset;
 import org.dcsa.conformance.core.traffic.HttpMessageType;
 import org.dcsa.conformance.standards.eblsurrender.party.EblSurrenderRole;
 
 @UtilityClass
 public class SurrenderChecks {
-
-  private static final KeywordDataset SURRENDER_ACTIONS_DATA_SET =
-      KeywordDataset.staticDataset(
-          "ISSUE", "ENDORSE", "SIGN", "SURRENDER_FOR_DELIVERY", "SURRENDER_FOR_AMENDMENT");
 
   private static final String ENDORSEMENT_CHAIN = "endorsementChain";
   private static final String ACTION_CODE = "actionCode";
@@ -49,7 +45,7 @@ public class SurrenderChecks {
                     ENDORSEMENT_CHAIN, RECIPIENT, IDENTIFYING_CODES, CODE_LIST_PROVIDER));
           },
           JsonAttribute.matchedMustBeDatasetKeywordIfPresent(
-              DOCUMENTATION_PARTY_CODE_LIST_PROVIDER_CODES));
+              SURRENDER_DOCUMENTATION_PARTY_CODE_LIST_PROVIDER_CODES));
 
   private static final JsonRebasableContentCheck REASON_CODE_CHECK =
       JsonAttribute.allIndividualMatchesMustBeValid(

--- a/ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EblDatasets.java
+++ b/ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EblDatasets.java
@@ -9,7 +9,7 @@ public class EblDatasets {
   public static final KeywordDataset EBL_PLATFORMS_DATASET =
       KeywordDataset.staticDataset(
           "WAVE", "CARX", "ESSD", "IDT", "BOLE", "EDOX", "IQAX", "SECR", "TRGO", "ETEU", "TRAC",
-          "BRIT");
+          "BRIT", "COVA", "ETIT", "KTNE", "CRED", "BLOC");
 
   public static final KeywordDataset CARGO_MOVEMENT_TYPE =
       KeywordDataset.staticDataset("FCL", "LCL");
@@ -45,6 +45,10 @@ public class EblDatasets {
           "WAVE", "CARX", "ESSD", "IDT", "BOLE", "EDOX", "IQAX", "SECR", "TRGO", "ETEU", "TRAC",
           "BRIT", "GSBN", "WISE", "GLEIF", "W3C", "DNB", "FMC", "DCSA", "ZZZ");
 
+  public static final KeywordDataset SURRENDER_DOCUMENTATION_PARTY_CODE_LIST_PROVIDER_CODES =
+      KeywordDataset.staticDataset(
+          "WAVE", "CARX", "ESSD", "IDT", "BOLE", "EDOX", "IQAX", "SECR", "TRGO", "ETEU", "TRAC",
+          "BRIT", "GSBN", "WISE", "GLEIF", "W3C", "DNB", "FMC", "DCSA", "ZZZ", "NONE");
   public static final KeywordDataset REASON_CODES =
       KeywordDataset.staticDataset("SWTP", "COD", "SWI");
 
@@ -74,4 +78,16 @@ public class EblDatasets {
           "PROPERTY_VALUE_HAS_BEEN_CHANGED",
           "PROPERTY_VALUE_MAY_CHANGE",
           "PROPERTY_HAS_BEEN_DELETED");
+
+  public static final KeywordDataset SURRENDER_ACTIONS_DATA_SET =
+      KeywordDataset.staticDataset(
+          "ISSUE",
+          "ENDORSE",
+          "SIGN",
+          "SURRENDER_FOR_DELIVERY",
+          "SURRENDER_FOR_AMENDMENT",
+          "BLANK_ENDORSE",
+          "ENDORSE_TO_ORDER",
+          "TRANSFER",
+          "SURRENDERED");
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Updated EBL platforms dataset with new platform codes

- Added new surrender action codes to dataset

- Created surrender-specific documentation party code list

- Refactored surrender checks to use centralized datasets


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["EblDatasets.java<br/>Dataset Definitions"] -->|"SURRENDER_ACTIONS_DATA_SET"| B["SurrenderChecks.java<br/>Validation Logic"]
  A -->|"SURRENDER_DOCUMENTATION_PARTY_CODE_LIST_PROVIDER_CODES"| B
  A -->|"EBL_PLATFORMS_DATASET<br/>Updated Codes"| C["Enhanced<br/>Validation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EblDatasets.java</strong><dd><code>Centralized surrender datasets and updated platform codes</code></dd></summary>
<hr>

ebl/src/main/java/org/dcsa/conformance/standards/ebl/checks/EblDatasets.java

<ul><li>Added 5 new platform codes to <code>EBL_PLATFORMS_DATASET</code> (COVA, ETIT, KTNE, <br>CRED, BLOC)<br> <li> Created new <code>SURRENDER_DOCUMENTATION_PARTY_CODE_LIST_PROVIDER_CODES</code> <br>dataset with NONE code<br> <li> Moved <code>SURRENDER_ACTIONS_DATA_SET</code> from SurrenderChecks to EblDatasets <br>with 5 new action codes<br> <li> New surrender action codes: BLANK_ENDORSE, ENDORSE_TO_ORDER, TRANSFER, <br>SURRENDERED</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/487/files#diff-cf98df85588aa7b9a52011751dbb93ad55da645327edf82e93832b773104f0fa">+17/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SurrenderChecks.java</strong><dd><code>Refactored to use centralized dataset definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/checks/SurrenderChecks.java

<ul><li>Removed local <code>SURRENDER_ACTIONS_DATA_SET</code> definition<br> <li> Updated imports to use centralized datasets from EblDatasets<br> <li> Changed reference from <code>DOCUMENTATION_PARTY_CODE_LIST_PROVIDER_CODES</code> to <br><code>SURRENDER_DOCUMENTATION_PARTY_CODE_LIST_PROVIDER_CODES</code><br> <li> Removed unused <code>KeywordDataset</code> import</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/487/files#diff-69ba8aefdb8bbe7606b1089ca9fc2475a1ab4b3163b576c12d55bbe417800dd0">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

