### PR TITLE
SD-2907: Remove redundant surrender scenarios

### DIFF
--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/EblSurrenderScenarioListBuilder.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/EblSurrenderScenarioListBuilder.java
@@ -37,11 +37,7 @@ class EblSurrenderScenarioListBuilder extends ScenarioListBuilder<EblSurrenderSc
                 "Surrender Accepted",
                 noAction()
                     .thenEither(
-                        supplyAvailableTdrAction("SURR", "Straight eBL")
-                            .thenEither(
-                                requestSurrenderForDeliveryAnd(true),
-                                requestSurrenderForAmendmentAnd(true)),
-                        supplyAvailableTdrAction("SURR", "Negotiable eBL")
+                        supplyAvailableTdrAction("SURR")
                             .thenEither(
                                 requestSurrenderForDeliveryAnd(true),
                                 requestSurrenderForAmendmentAnd(true)))),
@@ -49,18 +45,13 @@ class EblSurrenderScenarioListBuilder extends ScenarioListBuilder<EblSurrenderSc
                 "Surrender Rejected",
                 noAction()
                     .thenEither(
-                        supplyAvailableTdrAction("SREJ", "Straight eBL")
-                            .thenEither(
-                                requestSurrenderForDeliveryAnd(false),
-                                requestSurrenderForAmendmentAnd(false)),
-                        supplyAvailableTdrAction("SREJ", "Negotiable eBL")
+                        supplyAvailableTdrAction("SREJ")
                             .thenEither(
                                 requestSurrenderForDeliveryAnd(false),
                                 requestSurrenderForAmendmentAnd(false)))),
             Map.entry(
                 "Carrier error response conformance",
-                supplyAvailableTdrAction("SURR", "Straight eBl", true)
-                    .then(requestSurrenderError())))
+                supplyAvailableTdrErrorAction("SURR").then(requestSurrenderError())))
         .collect(
             Collectors.toMap(
                 Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
@@ -70,23 +61,20 @@ class EblSurrenderScenarioListBuilder extends ScenarioListBuilder<EblSurrenderSc
     return new EblSurrenderScenarioListBuilder(null);
   }
 
-  private static EblSurrenderScenarioListBuilder supplyAvailableTdrAction(
-      String response, String eblType) {
-    log.debug("EblSurrenderScenarioListBuilder.supplyAvailableTdrAction()");
-    String carrierPartyName = threadLocalCarrierPartyName.get();
-    return new EblSurrenderScenarioListBuilder(
-        noPreviousAction ->
-            new SupplyScenarioParametersAction(carrierPartyName, null, response, eblType));
+  private static EblSurrenderScenarioListBuilder supplyAvailableTdrAction(String response) {
+    return supplyAvailableTdrAction(response, false);
+  }
+
+  private static EblSurrenderScenarioListBuilder supplyAvailableTdrErrorAction(String response) {
+    return supplyAvailableTdrAction(response, true);
   }
 
   private static EblSurrenderScenarioListBuilder supplyAvailableTdrAction(
-      String response, String eblType, boolean isErrorScenario) {
+      String response, boolean isErrorScenario) {
     log.debug("EblSurrenderScenarioListBuilder.supplyAvailableTdrAction()");
     String carrierPartyName = threadLocalCarrierPartyName.get();
     return new EblSurrenderScenarioListBuilder(
-        noPreviousAction ->
-            new SupplyScenarioParametersAction(
-                carrierPartyName, null, response, eblType, isErrorScenario));
+        _ -> new SupplyScenarioParametersAction(carrierPartyName, null, response, isErrorScenario));
   }
 
   private static EblSurrenderScenarioListBuilder requestSurrenderForAmendmentAnd(boolean accept) {

--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SupplyScenarioParametersAction.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SupplyScenarioParametersAction.java
@@ -5,7 +5,6 @@ import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Map;
-import java.util.UUID;
 import lombok.Getter;
 import org.dcsa.conformance.core.scenario.ConformanceAction;
 import org.dcsa.conformance.core.util.ReferenceGenerator;
@@ -13,27 +12,18 @@ import org.dcsa.conformance.standards.eblsurrender.party.SuppliedScenarioParamet
 
 @Getter
 public class SupplyScenarioParametersAction extends ConformanceAction {
+
   private SuppliedScenarioParameters suppliedScenarioParameters = null;
   private String response;
-  private String eblType;
-  private boolean isErrorScenario = false;
-
-  public SupplyScenarioParametersAction(
-      String carrierPartyName, ConformanceAction previousAction, String response, String eblType) {
-    super(carrierPartyName, null, previousAction, "SupplyTDR[%s]".formatted(eblType));
-    this.response = response;
-    this.eblType = eblType;
-  }
+  private final boolean isErrorScenario;
 
   public SupplyScenarioParametersAction(
       String carrierPartyName,
       ConformanceAction previousAction,
       String response,
-      String eblType,
       boolean errorScenario) {
-    super(carrierPartyName, null, previousAction, "SupplyTDR[%s]".formatted(eblType));
+    super(carrierPartyName, null, previousAction, "SupplyTDR");
     this.response = response;
-    this.eblType = eblType;
     this.isErrorScenario = errorScenario;
   }
 
@@ -50,7 +40,6 @@ public class SupplyScenarioParametersAction extends ConformanceAction {
       jsonState.set("suppliedScenarioParameters", suppliedScenarioParameters.toJson());
     }
     jsonState.put("response", response);
-    jsonState.put("eblType", eblType);
     return jsonState;
   }
 
@@ -62,7 +51,6 @@ public class SupplyScenarioParametersAction extends ConformanceAction {
       suppliedScenarioParameters = SuppliedScenarioParameters.fromJson(sspNode);
     }
     response = jsonState.get("response").asText();
-    eblType = jsonState.get("eblType").asText();
   }
 
   @Override
@@ -70,12 +58,9 @@ public class SupplyScenarioParametersAction extends ConformanceAction {
     String responseAction = response.equals("SURR") ? "accept" : "reject";
     return isErrorScenario
         ? EblSurrenderAction.getMarkdownHumanReadablePrompt(
-            Map.of("EBL_TYPE", eblType), "prompt-surrender-error-ssp.md")
+            Map.of(), "prompt-surrender-error-ssp.md")
         : EblSurrenderAction.getMarkdownHumanReadablePrompt(
-            Map.of(
-                "EBL_TYPE", eblType,
-                "RESPONSE", responseAction),
-            "prompt-surrender-ssp.md");
+            Map.of("RESPONSE", responseAction), "prompt-surrender-ssp.md");
   }
 
   @Override
@@ -89,10 +74,7 @@ public class SupplyScenarioParametersAction extends ConformanceAction {
     var surrendereeParty = OBJECT_MAPPER.createObjectNode();
     surrendereeParty.put("partyName", "Surrenderee name").put("eblPlatform", "BOLE");
     return new SuppliedScenarioParameters(
-            ReferenceGenerator.newReference(),
-            issueToParty,
-            carrierParty,
-            surrendereeParty)
+            ReferenceGenerator.newReference(), issueToParty, carrierParty, surrendereeParty)
         .toJson();
   }
 
@@ -108,9 +90,6 @@ public class SupplyScenarioParametersAction extends ConformanceAction {
 
   @Override
   public ObjectNode asJsonNode() {
-    return super.asJsonNode()
-        .put("eblType", eblType)
-        .put("response", response)
-        .put("isErrorScenario", isErrorScenario);
+    return super.asJsonNode().put("response", response).put("errorScenario", isErrorScenario);
   }
 }

--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderCarrier.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderCarrier.java
@@ -26,7 +26,7 @@ import org.dcsa.conformance.standards.eblsurrender.action.SupplyScenarioParamete
 @Slf4j
 public class EblSurrenderCarrier extends ConformanceParty {
   private final Map<String, EblSurrenderState> eblStatesById = new HashMap<>();
-  private boolean errorScenario = false;
+  private boolean errorScenario;
 
   public EblSurrenderCarrier(
       String apiVersion,
@@ -84,8 +84,7 @@ public class EblSurrenderCarrier extends ConformanceParty {
             .formatted(actionPrompt.toPrettyString()));
 
     String tdr = ReferenceGenerator.newReference();
-    errorScenario =
-        actionPrompt.has("errorScenario") && actionPrompt.get("errorScenario").asBoolean();
+    errorScenario = actionPrompt.get("errorScenario").asBoolean(false);
     eblStatesById.put(tdr, EblSurrenderState.AVAILABLE_FOR_SURRENDER);
     persistentMap.save("response", actionPrompt.get("response"));
 

--- a/ebl-surrender/src/main/resources/standards/eblsurrender/instructions/prompt-surrender-error-ssp.md
+++ b/ebl-surrender/src/main/resources/standards/eblsurrender/instructions/prompt-surrender-error-ssp.md
@@ -1,4 +1,4 @@
-Please provide the required information for a **EBL_TYPE** that is **NOT available for surrender** in your system:
+Please provide the required information for a Straight or Negotiable eBL that is **NOT available for surrender** in your system:
 
 ### Required Information:
 - **Transport Document Reference**: An eBL reference that cannot be surrendered (e.g., already surrendered, cancelled, not yet issued)

--- a/ebl-surrender/src/main/resources/standards/eblsurrender/instructions/prompt-surrender-ssp.md
+++ b/ebl-surrender/src/main/resources/standards/eblsurrender/instructions/prompt-surrender-ssp.md
@@ -1,4 +1,4 @@
-Please provide the required information for a **EBL_TYPE** that your system can process:
+Please provide the required information for a Straight or Negotiable eBL that your system can process:
 
 ### Required Information:
 - **Transport Document Reference**: A valid eBL reference in your system


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove redundant eBL type parameter from surrender scenarios

- Consolidate duplicate scenario branches for Straight and Negotiable eBLs

- Simplify action method signatures by eliminating eblType parameter

- Update prompt templates to reference both eBL types generically


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Scenario Builder"] -->|"Remove eblType param"| B["supplyAvailableTdrAction"]
  B -->|"Consolidate branches"| C["Single scenario path"]
  C -->|"Simplify"| D["SupplyScenarioParametersAction"]
  D -->|"Update prompts"| E["Generic eBL references"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EblSurrenderScenarioListBuilder.java</strong><dd><code>Consolidate duplicate eBL type scenario branches</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/EblSurrenderScenarioListBuilder.java

<ul><li>Removed duplicate scenario branches for "Straight eBL" and "Negotiable <br>eBL"<br> <li> Consolidated <code>supplyAvailableTdrAction()</code> calls to single invocation per <br>scenario<br> <li> Introduced <code>supplyAvailableTdrErrorAction()</code> helper method for error <br>scenarios<br> <li> Simplified method signatures by removing <code>eblType</code> parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/491/files#diff-953b020e831225cdf74b6bf454999a2c7d204778903973b3e1481d1a3a496da2">+11/-23</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SupplyScenarioParametersAction.java</strong><dd><code>Remove eblType field and simplify action class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SupplyScenarioParametersAction.java

<ul><li>Removed <code>eblType</code> field and related constructor overload<br> <li> Removed unused <code>UUID</code> import<br> <li> Simplified action name from <code>SupplyTDR[eblType]</code> to generic <code>SupplyTDR</code><br> <li> Updated <code>exportJsonState()</code> and <code>importJsonState()</code> to exclude eblType<br> <li> Removed eblType from prompt template variable maps<br> <li> Changed <code>asJsonNode()</code> to use <code>errorScenario</code> instead of <code>isErrorScenario</code></ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/491/files#diff-a7c7500036609581821fd765e7bbcd5dc341370b2c5ffcf63c500ed42d537755">+7/-28</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EblSurrenderCarrier.java</strong><dd><code>Simplify error scenario flag handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderCarrier.java

<ul><li>Simplified <code>errorScenario</code> field initialization<br> <li> Updated error scenario detection to use <code>asBoolean(false)</code> with default <br>value<br> <li> Removed redundant null check logic</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/491/files#diff-610cb1fd43ae33705f3e9deb3d0e929d1c7d78d2936ee40d07e4816275a7ff13">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prompt-surrender-error-ssp.md</strong><dd><code>Update error prompt to generic eBL reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl-surrender/src/main/resources/standards/eblsurrender/instructions/prompt-surrender-error-ssp.md

<ul><li>Replaced <code>EBL_TYPE</code> placeholder with generic "Straight or Negotiable <br>eBL" text<br> <li> Maintains same instruction context for error scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/491/files#diff-2b767ac9417437aa46186fbbbe5ff75f4859506a2b94ab5ae8e77a8ffaa0e31d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>prompt-surrender-ssp.md</strong><dd><code>Update standard prompt to generic eBL reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ebl-surrender/src/main/resources/standards/eblsurrender/instructions/prompt-surrender-ssp.md

<ul><li>Replaced <code>EBL_TYPE</code> placeholder with generic "Straight or Negotiable <br>eBL" text<br> <li> Maintains same instruction context for normal scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/dcsaorg/Conformance-Gateway/pull/491/files#diff-8e0d7431d01ac18475dcee415ab2aba5c3e0e574eda6a5f01a52acc4686274d7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

