### PR TITLE
Merge dev to test

### DIFF
--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/EblSurrenderScenarioListBuilder.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/EblSurrenderScenarioListBuilder.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.dcsa.conformance.core.scenario.ConformanceAction;
 import org.dcsa.conformance.core.scenario.ScenarioListBuilder;
 import org.dcsa.conformance.standards.eblsurrender.action.SupplyScenarioParametersAction;
+import org.dcsa.conformance.standards.eblsurrender.action.SupplyScenarioParametersErrorAction;
 import org.dcsa.conformance.standards.eblsurrender.action.SurrenderRequestResponseAction;
 import org.dcsa.conformance.standards.eblsurrender.action.SurrenderRequestResponseErrorAction;
 import org.dcsa.conformance.standards.eblsurrender.party.EblSurrenderRole;
@@ -51,7 +52,7 @@ class EblSurrenderScenarioListBuilder extends ScenarioListBuilder<EblSurrenderSc
                                 requestSurrenderForAmendmentAnd(false)))),
             Map.entry(
                 "Carrier error response conformance",
-                supplyAvailableTdrErrorAction("SURR").then(requestSurrenderError())))
+                supplyAvailableTdrErrorAction().then(requestSurrenderError())))
         .collect(
             Collectors.toMap(
                 Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
@@ -61,20 +62,20 @@ class EblSurrenderScenarioListBuilder extends ScenarioListBuilder<EblSurrenderSc
     return new EblSurrenderScenarioListBuilder(null);
   }
 
-  private static EblSurrenderScenarioListBuilder supplyAvailableTdrAction(String response) {
-    return supplyAvailableTdrAction(response, false);
-  }
+  private static EblSurrenderScenarioListBuilder supplyAvailableTdrErrorAction() {
+    log.debug("EblSurrenderScenarioListBuilder.supplyAvailableTdrErrorAction()");
 
-  private static EblSurrenderScenarioListBuilder supplyAvailableTdrErrorAction(String response) {
-    return supplyAvailableTdrAction(response, true);
-  }
-
-  private static EblSurrenderScenarioListBuilder supplyAvailableTdrAction(
-      String response, boolean isErrorScenario) {
-    log.debug("EblSurrenderScenarioListBuilder.supplyAvailableTdrAction()");
     String carrierPartyName = threadLocalCarrierPartyName.get();
     return new EblSurrenderScenarioListBuilder(
-        _ -> new SupplyScenarioParametersAction(carrierPartyName, null, response, isErrorScenario));
+      _ -> new SupplyScenarioParametersErrorAction(carrierPartyName));
+  }
+
+  private static EblSurrenderScenarioListBuilder supplyAvailableTdrAction(String response) {
+    log.debug("EblSurrenderScenarioListBuilder.supplyAvailableTdrAction()");
+
+    String carrierPartyName = threadLocalCarrierPartyName.get();
+    return new EblSurrenderScenarioListBuilder(
+        _ -> new SupplyScenarioParametersAction(carrierPartyName, null, response, false));
   }
 
   private static EblSurrenderScenarioListBuilder requestSurrenderForAmendmentAnd(boolean accept) {

--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/EblSurrenderAction.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/EblSurrenderAction.java
@@ -1,14 +1,15 @@
 package org.dcsa.conformance.standards.eblsurrender.action;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import lombok.Getter;
 import org.dcsa.conformance.core.scenario.ConformanceAction;
 import org.dcsa.conformance.core.toolkit.IOToolkit;
 import org.dcsa.conformance.standards.eblsurrender.party.SuppliedScenarioParameters;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 @Getter
 public abstract class EblSurrenderAction extends ConformanceAction {

--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SupplyScenarioParametersErrorAction.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SupplyScenarioParametersErrorAction.java
@@ -1,0 +1,64 @@
+package org.dcsa.conformance.standards.eblsurrender.action;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.Getter;
+import org.dcsa.conformance.core.scenario.ConformanceAction;
+
+import java.util.Map;
+
+import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
+
+@Getter
+public class SupplyScenarioParametersErrorAction extends ConformanceAction {
+
+  private JsonNode inputBody = null;
+
+  public SupplyScenarioParametersErrorAction(String sourcePartyName) {
+    super(sourcePartyName, null, null, "SupplyTDR");
+  }
+
+  @Override
+  public void reset() {
+    super.reset();
+    inputBody = null;
+  }
+
+  @Override
+  public ObjectNode exportJsonState() {
+    ObjectNode jsonState = super.exportJsonState();
+    if (inputBody != null) {
+      jsonState.set("inputBody", inputBody);
+    }
+    return jsonState;
+  }
+
+  @Override
+  public void importJsonState(JsonNode jsonState) {
+    super.importJsonState(jsonState);
+    JsonNode sspNode = jsonState.get("inputBody");
+    if (sspNode != null) {
+      inputBody = sspNode;
+    }
+  }
+
+  @Override
+  public String getHumanReadablePrompt() {
+    return EblSurrenderAction.getMarkdownHumanReadablePrompt(Map.of(), "prompt-surrender-error-ssp.md");
+  }
+
+  @Override
+  public JsonNode getJsonForHumanReadablePrompt() {
+    return OBJECT_MAPPER.createObjectNode();
+  }
+
+  @Override
+  public boolean isInputRequired() {
+    return true;
+  }
+
+  @Override
+  protected void doHandlePartyInput(JsonNode partyInput) {
+    inputBody = partyInput.get("input");
+  }
+}

--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SupplyScenarioParametersErrorAction.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SupplyScenarioParametersErrorAction.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Getter;
 import org.dcsa.conformance.core.scenario.ConformanceAction;
+import org.dcsa.conformance.standards.eblsurrender.party.EblSurrenderCarrier;
 
 import java.util.Map;
 
@@ -49,7 +50,7 @@ public class SupplyScenarioParametersErrorAction extends ConformanceAction {
 
   @Override
   public JsonNode getJsonForHumanReadablePrompt() {
-    return OBJECT_MAPPER.createObjectNode();
+    return EblSurrenderCarrier.getExampleJsonBody();
   }
 
   @Override

--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SurrenderRequestResponseErrorAction.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SurrenderRequestResponseErrorAction.java
@@ -1,8 +1,9 @@
 package org.dcsa.conformance.standards.eblsurrender.action;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import lombok.Getter;
@@ -18,13 +19,9 @@ import org.dcsa.conformance.standards.eblsurrender.party.EblSurrenderRole;
 
 @Getter
 @Slf4j
-public class SurrenderRequestResponseErrorAction extends EblSurrenderAction {
+public class SurrenderRequestResponseErrorAction extends ConformanceAction {
 
-  public static final String SEND_NO_TRANSPORT_DOCUMENT_REFERENCE =
-      "sendNoTransportDocumentReference";
-
-  private final AtomicReference<String> surrenderRequestReference = new AtomicReference<>();
-  private final Supplier<String> srrSupplier = surrenderRequestReference::get;
+  private final Supplier<JsonNode> inputBodySupplier;
   private final JsonSchemaValidator responseSchemaValidator;
 
   public SurrenderRequestResponseErrorAction(
@@ -35,27 +32,21 @@ public class SurrenderRequestResponseErrorAction extends EblSurrenderAction {
     super(
         platformPartyName,
         carrierPartyName,
-        400,
         previousAction,
-        "SurrenderForDelivery (not available for surrender)");
+        "Surrender (Error)");
     this.responseSchemaValidator = responseSchemaValidator;
-  }
-
-  @Override
-  public Supplier<String> getSrrSupplier() {
-    return srrSupplier;
+    this.inputBodySupplier = findInputBodySupplier(previousAction);
   }
 
   @Override
   public String getHumanReadablePrompt() {
-    return getMarkdownHumanReadablePrompt(Map.of(), "prompt-surrender-reqres-error.md");
+    return EblSurrenderAction.getMarkdownHumanReadablePrompt(
+        Map.of(), "prompt-surrender-reqres-error.md");
   }
 
   @Override
   public ObjectNode asJsonNode() {
-    return super.asJsonNode()
-        .put("forAmendment", false)
-        .put(SEND_NO_TRANSPORT_DOCUMENT_REFERENCE, true);
+    return super.asJsonNode().set("inputBody", inputBodySupplier.get());
   }
 
   @Override
@@ -82,5 +73,11 @@ public class SurrenderRequestResponseErrorAction extends EblSurrenderAction {
                 responseSchemaValidator));
       }
     };
+  }
+
+  private static Supplier<JsonNode> findInputBodySupplier(ConformanceAction action) {
+    return action instanceof SupplyScenarioParametersErrorAction errorSupplyAction
+      ? errorSupplyAction::getInputBody
+      : findInputBodySupplier(action.getPreviousAction());
   }
 }

--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderCarrier.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderCarrier.java
@@ -22,11 +22,12 @@ import org.dcsa.conformance.core.traffic.ConformanceRequest;
 import org.dcsa.conformance.core.traffic.ConformanceResponse;
 import org.dcsa.conformance.core.util.ReferenceGenerator;
 import org.dcsa.conformance.standards.eblsurrender.action.SupplyScenarioParametersAction;
+import org.dcsa.conformance.standards.eblsurrender.action.SupplyScenarioParametersErrorAction;
 
 @Slf4j
 public class EblSurrenderCarrier extends ConformanceParty {
+
   private final Map<String, EblSurrenderState> eblStatesById = new HashMap<>();
-  private boolean errorScenario;
 
   public EblSurrenderCarrier(
       String apiVersion,
@@ -55,7 +56,6 @@ public class EblSurrenderCarrier extends ConformanceParty {
           arrayNode.add(entryNode);
         });
     targetObjectNode.set("eblStatesById", arrayNode);
-    targetObjectNode.put("errorScenario", errorScenario);
   }
 
   @Override
@@ -66,7 +66,6 @@ public class EblSurrenderCarrier extends ConformanceParty {
                 eblStatesById.put(
                     entryNode.get("key").asText(),
                     EblSurrenderState.valueOf(entryNode.get("value").asText())));
-    errorScenario = sourceObjectNode.get("errorScenario").asBoolean(false);
   }
 
   @Override
@@ -77,16 +76,16 @@ public class EblSurrenderCarrier extends ConformanceParty {
   @Override
   protected Map<Class<? extends ConformanceAction>, Consumer<JsonNode>> getActionPromptHandlers() {
     return Map.ofEntries(
-        Map.entry(SupplyScenarioParametersAction.class, this::supplyScenarioParameters));
+        Map.entry(SupplyScenarioParametersAction.class, this::supplyScenarioParameters),
+        Map.entry(SupplyScenarioParametersErrorAction.class, this::supplyErrorScenarioParameters));
   }
 
   private void supplyScenarioParameters(JsonNode actionPrompt) {
     log.info(
-        "EblSurrenderPlatform.supplyScenarioParameters(%s)"
+        "EblSurrenderCarrier.supplyScenarioParameters(%s)"
             .formatted(actionPrompt.toPrettyString()));
 
     String tdr = ReferenceGenerator.newReference();
-    errorScenario = actionPrompt.get("errorScenario").asBoolean(false);
     eblStatesById.put(tdr, EblSurrenderState.AVAILABLE_FOR_SURRENDER);
     persistentMap.save("response", actionPrompt.get("response"));
 
@@ -122,6 +121,26 @@ public class EblSurrenderCarrier extends ConformanceParty {
             .formatted(suppliedScenarioParameters.toJson().toPrettyString()));
   }
 
+  private void supplyErrorScenarioParameters(JsonNode actionPrompt) {
+    log.info(
+        "EblSurrenderCarrier.supplyErrorScenarioParameters(%s)"
+            .formatted(actionPrompt.toPrettyString()));
+
+    ObjectNode errorBody =
+        OBJECT_MAPPER
+            .createObjectNode()
+            .put("surrenderRequestCode", "SREQ")
+            .put("surrenderRequestReference", "*")
+            .put("transportDocumentReference", EblSurrenderPlatform.INVALID_TDR);
+
+    asyncOrchestratorPostPartyInput(
+        actionPrompt.required("actionId").asText(), errorBody);
+
+    addOperatorLogEntry(
+        "Submitting error scenario body (transportDocumentReference='%s')"
+            .formatted(EblSurrenderPlatform.INVALID_TDR));
+  }
+
   @Override
   public ConformanceResponse handleRequest(ConformanceRequest request) {
     log.info("EblSurrenderCarrier.handleRequest(%s)".formatted(request));
@@ -138,11 +157,16 @@ public class EblSurrenderCarrier extends ConformanceParty {
       action = persistentMap.load("response").asText();
     }
 
-      eblStatesById.put(
-          tdr,
-          Objects.equals("AREQ", src)
-              ? EblSurrenderState.AMENDMENT_SURRENDER_REQUESTED
-              : EblSurrenderState.DELIVERY_SURRENDER_REQUESTED);
+    if (tdr.equals(EblSurrenderPlatform.INVALID_TDR)) {
+      return return409(
+          request, "Simulated error response for surrender request reference '%s'".formatted(srr));
+    }
+
+    eblStatesById.put(
+        tdr,
+        Objects.equals("AREQ", src)
+            ? EblSurrenderState.AMENDMENT_SURRENDER_REQUESTED
+            : EblSurrenderState.DELIVERY_SURRENDER_REQUESTED);
 
     var carrierResponse =
         OBJECT_MAPPER
@@ -151,14 +175,9 @@ public class EblSurrenderCarrier extends ConformanceParty {
             .put("action", action);
     asyncCounterpartNotification(null, "/v3/ebl-surrender-responses", carrierResponse);
 
-      addOperatorLogEntry(
-          "Handling surrender request with surrenderRequestCode '%s' and surrenderRequestReference '%s' for eBL with transportDocumentReference '%s' (now in state '%s')"
-              .formatted(src, srr, tdr, eblStatesById.get(tdr)));
-
-    if (errorScenario || tdr.equals(EblSurrenderPlatform.INVALID_TDR)) {
-      return return409(
-          request, "Simulated error response for surrender request reference '%s'".formatted(srr));
-    }
+    addOperatorLogEntry(
+        "Handling surrender request with surrenderRequestCode '%s' and surrenderRequestReference '%s' for eBL with transportDocumentReference '%s' (now in state '%s')"
+            .formatted(src, srr, tdr, eblStatesById.get(tdr)));
 
     return request.createResponse(
         204,

--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderCarrier.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderCarrier.java
@@ -126,12 +126,7 @@ public class EblSurrenderCarrier extends ConformanceParty {
         "EblSurrenderCarrier.supplyErrorScenarioParameters(%s)"
             .formatted(actionPrompt.toPrettyString()));
 
-    ObjectNode errorBody =
-        OBJECT_MAPPER
-            .createObjectNode()
-            .put("surrenderRequestCode", "SREQ")
-            .put("surrenderRequestReference", "*")
-            .put("transportDocumentReference", EblSurrenderPlatform.INVALID_TDR);
+    ObjectNode errorBody = getExampleJsonBody();
 
     asyncOrchestratorPostPartyInput(
         actionPrompt.required("actionId").asText(), errorBody);
@@ -139,6 +134,14 @@ public class EblSurrenderCarrier extends ConformanceParty {
     addOperatorLogEntry(
         "Submitting error scenario body (transportDocumentReference='%s')"
             .formatted(EblSurrenderPlatform.INVALID_TDR));
+  }
+
+  public static ObjectNode getExampleJsonBody() {
+    return OBJECT_MAPPER
+        .createObjectNode()
+      .put("surrenderRequestReference", "EXAMPLE_SRR")
+      .put("surrenderRequestCode", "SREQ")
+      .put("transportDocumentReference", EblSurrenderPlatform.INVALID_TDR);
   }
 
   @Override

--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderPlatform.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderPlatform.java
@@ -70,7 +70,17 @@ public class EblSurrenderPlatform extends ConformanceParty {
   protected Map<Class<? extends ConformanceAction>, Consumer<JsonNode>> getActionPromptHandlers() {
     return Map.ofEntries(
         Map.entry(SurrenderRequestResponseAction.class, this::requestSurrender),
-        Map.entry(SurrenderRequestResponseErrorAction.class, this::requestSurrender));
+        Map.entry(SurrenderRequestResponseErrorAction.class, this::requestErrorSurrender));
+  }
+
+  private void requestErrorSurrender(JsonNode actionPrompt) {
+    log.info("EblSurrenderPlatform.requestErrorSurrender(%s)".formatted(actionPrompt.toPrettyString()));
+
+    JsonNode inputBody = actionPrompt.get("inputBody");
+
+    syncCounterpartPost("/v%s/ebl-surrender-requests".formatted(apiVersion.charAt(0)), inputBody);
+
+    addOperatorLogEntry("Sent an invalid surrender request with body: %s".formatted(inputBody));
   }
 
   private void requestSurrender(JsonNode actionPrompt) {
@@ -110,14 +120,6 @@ public class EblSurrenderPlatform extends ConformanceParty {
                 Map.entry(
                     "SURRENDER_ACTION_CODE_PLACEHOLDER",
                     forAmendment ? "SURRENDER_FOR_AMENDMENT" : "SURRENDER_FOR_DELIVERY")));
-
-    boolean errorScenario =
-        actionPrompt
-            .path(SurrenderRequestResponseErrorAction.SEND_NO_TRANSPORT_DOCUMENT_REFERENCE)
-            .asBoolean(false);
-    if (errorScenario) {
-      ((ObjectNode) jsonRequestBody).put("transportDocumentReference", INVALID_TDR);
-    }
 
     syncCounterpartPost(
         "/v%s/ebl-surrender-requests".formatted(apiVersion.charAt(0)), jsonRequestBody);

--- a/ebl-surrender/src/main/resources/standards/eblsurrender/instructions/prompt-surrender-error-ssp.md
+++ b/ebl-surrender/src/main/resources/standards/eblsurrender/instructions/prompt-surrender-error-ssp.md
@@ -1,6 +1,8 @@
 Please provide the information required to trigger an error in your system when processing an eBL surrender request.
 
-This scenario is intended to validate your system’s error-handling behavior. There are no mandatory fields for this request, so you may provide any valid or invalid request data that causes your system to reject the surrender request.
+This scenario is intended to validate your system’s error handling behavior. Bellow we provide a very basic payload
+example, but there are no mandatory fields for this request, so you may provide any valid or invalid request data that
+causes your system to throw an error.
 
 For the full request structure, refer to the DCSA eBL Surrender API schema.
 

--- a/ebl-surrender/src/main/resources/standards/eblsurrender/instructions/prompt-surrender-error-ssp.md
+++ b/ebl-surrender/src/main/resources/standards/eblsurrender/instructions/prompt-surrender-error-ssp.md
@@ -1,28 +1,13 @@
-Please provide the required information for a Straight or Negotiable eBL that is **NOT available for surrender** in your system:
+Please provide the information required to trigger an error in your system when processing an eBL surrender request.
 
-### Required Information:
-- **Transport Document Reference**: An eBL reference that cannot be surrendered (e.g., already surrendered, cancelled, not yet issued)
-- **Carrier Party**: Your carrier party details
-- **Issue To Party**: The party to whom the eBL was issued
-- **Surrenderee Party**: The party requesting the surrender
+This scenario is intended to validate your system’s error-handling behavior. There are no mandatory fields for this request, so you may provide any valid or invalid request data that causes your system to reject the surrender request.
 
-### Party Object Structure:
-
-Each party object **`carrierParty`**, **`issueToParty`** and **`surrendereeParty`** requires:
-- `partyName`
-- `eblPlatform`.
-
-If your carrier system requires additional fields to process the surrender request, you can add:
-- `identifyingCodes`
-- `taxLegalReferences`
-- `representedParty`
-
-See the EBL Surrender API schema for the full structure of these optional fields.
+For the full request structure, refer to the DCSA eBL Surrender API schema.
 
 ### What Happens Next:
 
-1. The conformance platform will send a surrender request to your carrier system
-2. Your system should automatically **reject the request with an error response** (HTTP 400 or 409)
+1. The conformance platform will send the payload you specify below as a surrender request to your system
+2. Your system should automatically **reject the request with an error response**
 3. The platform will validate your error response against the DCSA eBL Surrender API standard
 
 **Note:** If you do not send a response, the conformance report will show "❔" (missing traffic) for the response checks.

--- a/ebl-surrender/src/main/resources/standards/eblsurrender/instructions/prompt-surrender-reqres-error.md
+++ b/ebl-surrender/src/main/resources/standards/eblsurrender/instructions/prompt-surrender-reqres-error.md
@@ -1,14 +1,4 @@
-Send a surrender request from your platform to the synthetic carrier for an eBL that is **not available for surrender**.
+This scenario is intended to validate that the carrier system returns an error response that conforms to the DCSA eBL
+Surrender API standard.
 
-### What Happens:
-
-1. **Your platform sends**: POST request to `/ebl-surrender-requests` with the surrender request details
-2. **Synthetic carrier responds**: HTTP 400 (Bad Request) or HTTP 409 (Conflict) with an error response
-3. **Conformance validates**: Your platform's request conforms to the DCSA eBL Surrender API standard and properly handles the error response
-
-### Next Steps:
-
-Press **"Refresh status"** to update the scenario status and view conformance check results.
-
-Press **"Action completed"** when you have sent the request and handled the error response.
-
+This is a carrier side scenario only. You do not need to perform this action or execute this scenario.


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Align eBL surrender error scenario with real carrier error handling
<code>🐞 Bug fix</code> <code>✨ Enhancement</code> <code>📝 Documentation</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Replace synthetic “missing TDR” error with operator-supplied request body for error triggering
• Propagate the supplied input payload through actions into the platform’s error surrender request
• Update carrier/platform behavior and prompts to reflect carrier-side-only error conformance
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["ScenarioListBuilder"] --> B["SupplyScenarioParametersErrorAction"] --> C["SurrenderRequestResponseErrorAction"] --> D["EblSurrenderPlatform"] --> E["EblSurrenderCarrier"]
  B --> F["prompt-surrender-error-ssp.md"]
  C --> G["prompt-surrender-reqres-error.md"]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Keep single SupplyScenarioParametersAction with an error-mode flag</b></summary>

- ➕ Avoids introducing a new action class and duplicated state import/export
- ➕ Keeps scenario parameter collection consolidated in one place
- ➖ Mixes two different user interactions (normal parameter supply vs arbitrary error payload)
- ➖ Requires overloading existing action semantics and prompt/json generation

</details>

<details>
<summary><b>2. Store the error request body in a shared scenario context/state object</b></summary>

- ➕ Decouples payload storage from action chain traversal logic
- ➕ Avoids recursive previousAction scanning to find the supplier
- ➖ Requires introducing/standardizing a cross-action context mechanism
- ➖ Potentially larger refactor across the conformance framework

</details>

<details>
<summary><b>3. Make the carrier error condition parameterized (code-based) instead of payload-based</b></summary>

- ➕ More deterministic and easier to reproduce (e.g., pick error case from a list)
- ➕ Reduces risk of users providing payloads that don’t trigger an error
- ➖ Less representative of real-world carrier error triggers
- ➖ May not match how participant systems actually fail in practice

</details>

**Recommendation:** The PR’s approach (a dedicated error-parameter action that captures a payload and forwards it) is a good fit for “real situation” testing because it lets implementers provide whatever body actually triggers their system’s error path. If this pattern expands to more scenarios, consider a shared scenario context to avoid recursive previous-action traversal for data extraction.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>SupplyScenarioParametersErrorAction.java</strong> <code>Add action to collect and persist an error-triggering request payload</code> <code>+65/-0</code></summary>

<br/>

>Add action to collect and persist an error-triggering request payload
>
><pre>
>• Adds a new ConformanceAction that prompts the operator for an arbitrary surrender request body, persists it via JSON state export/import, and exposes it for downstream actions. Uses the carrier’s example JSON body for prompt rendering.
></pre>
>
><a href='https://github.com/dcsaorg/Conformance-Gateway/pull/519/files#diff-0fb2af5582be64e5645854d48a478b38819c611f7aeceb2b9ee961629ee0e73c'>ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SupplyScenarioParametersErrorAction.java</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Bug fix</strong> (4)</summary>

<blockquote>
<details>
<summary><strong>EblSurrenderScenarioListBuilder.java</strong> <code>Wire carrier error scenario to a dedicated error-parameter supply action</code> <code>+10/-9</code></summary>

<br/>

>Wire carrier error scenario to a dedicated error-parameter supply action
>
><pre>
>• Replaces the prior error-scenario setup that passed a response flag into the standard parameter supplier. Introduces a dedicated builder method that creates SupplyScenarioParametersErrorAction and updates the carrier error response conformance scenario to use it.
></pre>
>
><a href='https://github.com/dcsaorg/Conformance-Gateway/pull/519/files#diff-953b020e831225cdf74b6bf454999a2c7d204778903973b3e1481d1a3a496da2'>ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/EblSurrenderScenarioListBuilder.java</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>SurrenderRequestResponseErrorAction.java</strong> <code>Forward supplied inputBody into the error request action payload</code> <code>+15/-18</code></summary>

<br/>

>Forward supplied inputBody into the error request action payload
>
><pre>
>• Stops inheriting from EblSurrenderAction and instead becomes a ConformanceAction that embeds the upstream-provided inputBody into its JSON representation. Locates the inputBody by walking previous actions until it finds SupplyScenarioParametersErrorAction.
></pre>
>
><a href='https://github.com/dcsaorg/Conformance-Gateway/pull/519/files#diff-50d6c265760ffdf746250223861e2149aff96c71738aa39cec0304a031435323'>ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SurrenderRequestResponseErrorAction.java</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>EblSurrenderCarrier.java</strong> <code>Remove errorScenario flag and simulate error via invalid TDR payload</code> <code>+41/-19</code></summary>

<br/>

>Remove errorScenario flag and simulate error via invalid TDR payload
>
><pre>
>• Adds a prompt handler for SupplyScenarioParametersErrorAction that submits a predefined error payload. Removes persisted errorScenario state and changes request handling to return 409 only when the request uses INVALID_TDR; otherwise it proceeds with normal state transitions and notifications.
></pre>
>
><a href='https://github.com/dcsaorg/Conformance-Gateway/pull/519/files#diff-610cb1fd43ae33705f3e9deb3d0e929d1c7d78d2936ee40d07e4816275a7ff13'>ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderCarrier.java</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>EblSurrenderPlatform.java</strong> <code>Add dedicated handler for error surrender requests using inputBody</code> <code>+11/-9</code></summary>

<br/>

>Add dedicated handler for error surrender requests using inputBody
>
><pre>
>• Routes SurrenderRequestResponseErrorAction prompts to a new handler that posts the provided inputBody directly. Removes legacy logic that mutated a generated body based on a boolean flag to omit/override the transportDocumentReference.
></pre>
>
><a href='https://github.com/dcsaorg/Conformance-Gateway/pull/519/files#diff-d17ab3dc70ad88a2ed9dcc4c5e9355d61ae7ffd3b4b1265d90c4bb463d89080c'>ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderPlatform.java</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Refactor</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>EblSurrenderAction.java</strong> <code>Reorder imports for consistency</code> <code>+5/-4</code></summary>

<br/>

>Reorder imports for consistency
>
><pre>
>• Moves Java utility imports below project imports without functional changes.
></pre>
>
><a href='https://github.com/dcsaorg/Conformance-Gateway/pull/519/files#diff-0c537c53829ecaf80ed9c28428b53bf964d50aff0c744ddfe6a7d5cacf6379f6'>ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/EblSurrenderAction.java</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>prompt-surrender-error-ssp.md</strong> <code>Rewrite error scenario instructions to accept arbitrary error-triggering payloads</code> <code>+7/-20</code></summary>

<br/>

>Rewrite error scenario instructions to accept arbitrary error-triggering payloads
>
><pre>
>• Updates the operator guidance from “provide an eBL not available for surrender” to “provide any payload that triggers an error.” Clarifies that there are no mandatory fields and the platform will validate the carrier error response.
></pre>
>
><a href='https://github.com/dcsaorg/Conformance-Gateway/pull/519/files#diff-2b767ac9417437aa46186fbbbe5ff75f4859506a2b94ab5ae8e77a8ffaa0e31d'>ebl-surrender/src/main/resources/standards/eblsurrender/instructions/prompt-surrender-error-ssp.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>prompt-surrender-reqres-error.md</strong> <code>Clarify that error conformance scenario is carrier-side only</code> <code>+3/-13</code></summary>

<br/>

>Clarify that error conformance scenario is carrier-side only
>
><pre>
>• Replaces step-by-step platform instructions with a brief note that the scenario validates carrier error responses and requires no user action on the platform side.
></pre>
>
><a href='https://github.com/dcsaorg/Conformance-Gateway/pull/519/files#diff-c9ac9ce75aa739a1985c594168f8c4dea3d52ed6044f4685953fa59ffa19fcdf'>ebl-surrender/src/main/resources/standards/eblsurrender/instructions/prompt-surrender-reqres-error.md</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>