### PR TITLE
SD-3091: Update SSP action to not have mandatory fields

### DIFF
--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SupplyScenarioParametersErrorAction.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SupplyScenarioParametersErrorAction.java
@@ -8,8 +8,6 @@ import org.dcsa.conformance.standards.eblsurrender.party.EblSurrenderCarrier;
 
 import java.util.Map;
 
-import static org.dcsa.conformance.core.toolkit.JsonToolkit.OBJECT_MAPPER;
-
 @Getter
 public class SupplyScenarioParametersErrorAction extends ConformanceAction {
 
@@ -61,5 +59,9 @@ public class SupplyScenarioParametersErrorAction extends ConformanceAction {
   @Override
   protected void doHandlePartyInput(JsonNode partyInput) {
     inputBody = partyInput.get("input");
+  }
+
+  public Map<String, Boolean> getExpectedInputAttributes() {
+    return Map.of();
   }
 }

--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SurrenderRequestResponseErrorAction.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SurrenderRequestResponseErrorAction.java
@@ -2,10 +2,6 @@ package org.dcsa.conformance.standards.eblsurrender.action;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import java.util.Map;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.dcsa.conformance.core.check.ApiHeaderCheck;
@@ -16,6 +12,10 @@ import org.dcsa.conformance.core.check.JsonSchemaValidator;
 import org.dcsa.conformance.core.scenario.ConformanceAction;
 import org.dcsa.conformance.core.traffic.HttpMessageType;
 import org.dcsa.conformance.standards.eblsurrender.party.EblSurrenderRole;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 @Getter
 @Slf4j

--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderCarrier.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderCarrier.java
@@ -27,6 +27,10 @@ import org.dcsa.conformance.standards.eblsurrender.action.SupplyScenarioParamete
 @Slf4j
 public class EblSurrenderCarrier extends ConformanceParty {
 
+  private static final String PLACEHOLDER_TDR = "PLACEHOLDER_TDR";
+  public static final String PLACEHOLDER_SRR = "PLACEHOLDER_SRR";
+  public static final String PLACEHOLDER_SRC = "PLACEHOLDER_SRC";
+
   private final Map<String, EblSurrenderState> eblStatesById = new HashMap<>();
 
   public EblSurrenderCarrier(
@@ -133,15 +137,15 @@ public class EblSurrenderCarrier extends ConformanceParty {
 
     addOperatorLogEntry(
         "Submitting error scenario body (transportDocumentReference='%s')"
-            .formatted(EblSurrenderPlatform.INVALID_TDR));
+            .formatted(PLACEHOLDER_TDR));
   }
 
   public static ObjectNode getExampleJsonBody() {
     return OBJECT_MAPPER
         .createObjectNode()
-      .put("surrenderRequestReference", "EXAMPLE_SRR")
-      .put("surrenderRequestCode", "SREQ")
-      .put("transportDocumentReference", EblSurrenderPlatform.INVALID_TDR);
+      .put("surrenderRequestReference", PLACEHOLDER_SRR)
+      .put("transportDocumentReference", PLACEHOLDER_TDR)
+      .put("surrenderRequestCode", PLACEHOLDER_SRC);
   }
 
   @Override
@@ -160,7 +164,7 @@ public class EblSurrenderCarrier extends ConformanceParty {
       action = persistentMap.load("response").asText();
     }
 
-    if (tdr.equals(EblSurrenderPlatform.INVALID_TDR)) {
+    if (tdr.equals(PLACEHOLDER_TDR)) {
       return return409(
           request, "Simulated error response for surrender request reference '%s'".formatted(srr));
     }

--- a/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderPlatform.java
+++ b/ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderPlatform.java
@@ -26,7 +26,6 @@ import org.dcsa.conformance.standards.eblsurrender.action.SurrenderRequestRespon
 @Slf4j
 public class EblSurrenderPlatform extends ConformanceParty {
 
-  public static final String INVALID_TDR = "CONFORMANCE-INVALID-TDR";
   private final Map<String, EblSurrenderState> eblStatesById = new HashMap<>();
   private final Map<String, String> tdrsBySrr = new HashMap<>();
 


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

SD-3091: Allow SSP error action input without mandatory fields
<code>🐞 Bug fix</code> <code>✨ Enhancement</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Remove mandatory-field validation for the SSP error input body.
• Replace INVALID_TDR usage with explicit placeholder constants for error scenarios.
• Keep error request/response action wiring intact while allowing freer invalid payloads.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  O(("Operator")) --> A["SSP Error Action"] --> P["Platform party"] --> C["Carrier party"] --> R["409 error response"]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Mark known fields optional (instead of disabling validation)</b></summary>

- ➕ Still prevents unexpected attributes/typos while allowing omission of known fields
- ➕ More controlled operator input while meeting &#x27;no mandatory fields&#x27; requirement
- ➖ Prevents fully arbitrary invalid bodies (e.g., experimenting with extra/malformed fields)
- ➖ Requires explicitly listing all known fields for this action

</details>

<details>
<summary><b>2. Make carrier error handling resilient to missing fields</b></summary>

- ➕ Allows truly invalid/missing-field payloads without NPE risk in carrier simulation
- ➕ More robust conformance harness behavior under malformed inputs
- ➖ More code changes and decision-making about defaults/error paths
- ➖ Could mask issues if missing fields should fail fast in some scenarios

</details>

**Recommendation:** If the intent is to let operators craft any malformed payload, the current approach (returning an empty expected-attributes map) is the simplest and most flexible. If the intent is only to remove *mandatory* constraints while still rejecting unknown keys, consider switching to an explicit expected-attributes map with all entries set to optional (false).

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>EblSurrenderCarrier.java</strong> <code>Use explicit placeholder values for error surrender requests</code> <code>+9/-5</code></summary>

<br/>

>Use explicit placeholder values for error surrender requests
>
><pre>
>• Introduces placeholder constants for SRR/SRC/TDR and updates example error body generation and logging to use them. Carrier now triggers the simulated 409 when the placeholder TDR is received.
></pre>
>
><a href='https://github.com/dcsaorg/Conformance-Gateway/pull/520/files#diff-610cb1fd43ae33705f3e9deb3d0e929d1c7d78d2936ee40d07e4816275a7ff13'>ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderCarrier.java</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>SupplyScenarioParametersErrorAction.java</strong> <code>Disable mandatory attribute validation for SSP error input</code> <code>+4/-2</code></summary>

<br/>

>Disable mandatory attribute validation for SSP error input
>
><pre>
>• Overrides getExpectedInputAttributes() to return an empty map so the error SSP action no longer enforces required keys based on the example JSON. Also removes an unused static import.
></pre>
>
><a href='https://github.com/dcsaorg/Conformance-Gateway/pull/520/files#diff-0fb2af5582be64e5645854d48a478b38819c611f7aeceb2b9ee961629ee0e73c'>ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SupplyScenarioParametersErrorAction.java</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Refactor</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>SurrenderRequestResponseErrorAction.java</strong> <code>Reorder imports (no functional change)</code> <code>+4/-4</code></summary>

<br/>

>Reorder imports (no functional change)
>
><pre>
>• Moves java.* imports to the standard import grouping; behavior and logic are unchanged.
></pre>
>
><a href='https://github.com/dcsaorg/Conformance-Gateway/pull/520/files#diff-50d6c265760ffdf746250223861e2149aff96c71738aa39cec0304a031435323'>ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/action/SurrenderRequestResponseErrorAction.java</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>EblSurrenderPlatform.java</strong> <code>Remove INVALID_TDR constant</code> <code>+0/-1</code></summary>

<br/>

>Remove INVALID_TDR constant
>
><pre>
>• Drops the INVALID_TDR constant (error scenario now relies on carrier-side placeholder constants instead).
></pre>
>
><a href='https://github.com/dcsaorg/Conformance-Gateway/pull/520/files#diff-d17ab3dc70ad88a2ed9dcc4c5e9355d61ae7ffd3b4b1265d90c4bb463d89080c'>ebl-surrender/src/main/java/org/dcsa/conformance/standards/eblsurrender/party/EblSurrenderPlatform.java</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>